### PR TITLE
draft(task_either): tryCatch refactor

### DIFF
--- a/testing/task_either.test.ts
+++ b/testing/task_either.test.ts
@@ -37,6 +37,10 @@ Deno.test("TaskEither tryCatch", async (t) => {
     T.right(expectedRight),
   );
   await assertEqualsT(
+    T.tryCatch(taskOf(2), String)(),
+    T.right(expectedRight),
+  );
+  await assertEqualsT(
     T.tryCatch(
       (..._args: [string, ...string[]]) => throws(),
       (_err, ...args) => args.join(" "),


### PR DESCRIPTION
We talked about a new way of dealing with `tryCatch` in #50 
This is a draft / POC PR of what was discussed there, for easier discussion everything is easily testable from this PR. 
