### PR TITLE
feat: udpate types.ts for fun 2.0

### DIFF
--- a/apply.ts
+++ b/apply.ts
@@ -2,7 +2,7 @@
 import type { Kind, URIS } from "./kind.ts";
 import type { Functor } from "./functor.ts";
 import type { Semigroup } from "./semigroup.ts";
-import type { NonEmptyArray, NonEmptyRecord } from "./types.ts";
+import type { NonEmptyRecord } from "./types.ts";
 
 import { pipe } from "./fns.ts";
 
@@ -32,6 +32,8 @@ function _loopRecord<K extends string>(
     ? init
     : (a: unknown) => _loopRecord(keys, i + 1, { ...init, [keys[i]]: a });
 }
+
+type NonEmptyArray<A> = readonly [A, ...A[]];
 
 // deno-fmt-ignore
 type SequenceTuple<URI extends URIS, R extends NonEmptyArray<Kind<URI, any[]>>> = Kind<URI, [

--- a/array.ts
+++ b/array.ts
@@ -1,8 +1,9 @@
 import { Kind, URIS } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Separated } from "./separated.ts";
-import type { Predicate, Refinement } from "./types.ts";
 import type { Option } from "./option.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import { separated } from "./separated.ts";
 import { none, some } from "./option.ts";

--- a/boolean.ts
+++ b/boolean.ts
@@ -5,3 +5,7 @@ export function equals(second: boolean): (first: boolean) => boolean {
 }
 
 export const Setoid: T.Setoid<boolean> = { equals };
+
+export const constTrue = () => true;
+
+export const constFalse = () => false;

--- a/contravariant.ts
+++ b/contravariant.ts
@@ -6,9 +6,9 @@ import type { Kind, URIS } from "./kind.ts";
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#contravariant
  */
 export interface Contravariant<URI extends URIS, _ extends any[] = any[]> {
-  readonly contramap: <A, I>(
-    fai: (a: A) => I,
+  readonly contramap: <I, A>(
+    fia: (i: I) => A,
   ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    tb: Kind<URI, [I, B, C, D]>,
-  ) => Kind<URI, [A, B, C, D]>;
+    ua: Kind<URI, [A, B, C, D]>,
+  ) => Kind<URI, [I, B, C, D]>;
 }

--- a/datum.ts
+++ b/datum.ts
@@ -1,7 +1,8 @@
 import type { Kind, URIS } from "./kind.ts";
 import type * as T from "./types.ts";
 
-import { apply, flow, identity, isNotNil, pipe } from "./fns.ts";
+import { isNotNil } from "./nilable.ts";
+import { apply, flow, identity, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 
 export type Initial = {

--- a/either.ts
+++ b/either.ts
@@ -1,9 +1,11 @@
 import type { Kind, URIS } from "./kind.ts";
 import type * as T from "./types.ts";
-import type { Fn, Predicate, Refinement } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import * as O from "./option.ts";
-import { flow, isNotNil, pipe } from "./fns.ts";
+import { isNotNil } from "./nilable.ts";
+import { flow, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 
 export type Left<L> = { tag: "Left"; left: L };
@@ -63,9 +65,9 @@ export function tryCatch<E, A>(
 }
 
 export function tryCatchWrap<E, A, AS extends unknown[]>(
-  fn: Fn<AS, A>,
+  fn: (...as: AS) => A,
   onError: (e: unknown) => E,
-): Fn<AS, Either<E, A>> {
+): (...as: AS) => Either<E, A> {
   return (...as: AS) => {
     try {
       return right(fn(...as));

--- a/filterable.ts
+++ b/filterable.ts
@@ -1,10 +1,12 @@
 //deno-lint-ignore-file no-explicit-any
 import type { Kind, URIS } from "./kind.ts";
-import type { Predicate } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
 
 /**
  * Filterable
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#filterable
+ *
+ * TODO; add refine method
  */
 export interface Filterable<URI extends URIS, _ extends any[] = any[]> {
   readonly filter: <A>(

--- a/guard.ts
+++ b/guard.ts
@@ -1,6 +1,6 @@
 import type * as __ from "./kind.ts";
 
-import { isNil } from "./fns.ts";
+import { isNil } from "./nilable.ts";
 import * as S from "./schemable.ts";
 
 export type Guard<A, B extends A> = (a: A) => a is B;

--- a/iso.ts
+++ b/iso.ts
@@ -2,7 +2,8 @@ import type * as T from "./types.ts";
 import type { Kind, URIS } from "./kind.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
-import type { Predicate, Refinement } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import type { Optic } from "./optic.ts";
 import type { Lens } from "./lens.ts";

--- a/lens.ts
+++ b/lens.ts
@@ -1,8 +1,9 @@
 import type * as T from "./types.ts";
 import type { Kind, URIS } from "./kind.ts";
-import type { Predicate, Refinement } from "./types.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import type { Optic } from "./optic.ts";
 import type { Iso } from "./iso.ts";

--- a/map.ts
+++ b/map.ts
@@ -1,6 +1,6 @@
-import type { Kind } from "./kind.ts";
-import type { Option } from "./option.ts";
+import type * as __ from "./kind.ts";
 import type * as T from "./types.ts";
+import type { Option } from "./option.ts";
 
 import * as O from "./option.ts";
 import * as A from "./array.ts";

--- a/newtype.ts
+++ b/newtype.ts
@@ -8,9 +8,10 @@
  * specified.
  */
 
-import type { Monoid, Ord, Predicate, Semigroup, Setoid } from "./types.ts";
+import type { Monoid, Ord, Semigroup, Setoid } from "./types.ts";
 import type { Iso } from "./iso.ts";
 import type { Prism } from "./prism.ts";
+import type { Predicate } from "./predicate.ts";
 
 import * as I from "./iso.ts";
 import * as P from "./prism.ts";

--- a/nilable.ts
+++ b/nilable.ts
@@ -6,9 +6,9 @@
  * Nilable is a type like Maybe/Option that uses undefined/null in lieu of tagged unions.
  * *****************************************************************************/
 
-import type { Kind } from "./kind.ts";
-import type { Predicate } from "./types.ts";
+import type * as __ from "./kind.ts";
 import type * as T from "./types.ts";
+import type { Predicate } from "./predicate.ts";
 
 import { identity, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";

--- a/option.ts
+++ b/option.ts
@@ -1,9 +1,10 @@
-import type { Kind, URIS } from "./kind.ts";
-import type { Predicate } from "./types.ts";
 import type * as T from "./types.ts";
+import type { Kind, URIS } from "./kind.ts";
+import type { Predicate } from "./predicate.ts";
 
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
-import { flow, identity, isNotNil, pipe } from "./fns.ts";
+import { isNotNil } from "./nilable.ts";
+import { flow, identity, pipe } from "./fns.ts";
 
 /**
  * The None type represents the non-existence of a value.

--- a/optional.ts
+++ b/optional.ts
@@ -1,8 +1,9 @@
 import type * as T from "./types.ts";
 import type { Kind, URIS } from "./kind.ts";
-import type { Predicate, Refinement } from "./types.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import type { Optic } from "./optic.ts";
 import type { Iso } from "./iso.ts";

--- a/ord.ts
+++ b/ord.ts
@@ -1,5 +1,4 @@
 import type { Setoid } from "./setoid.ts";
-import type { Fn } from "./types.ts";
 
 import { flow, lessThanOrEqual, strictEquals } from "./fns.ts";
 
@@ -7,13 +6,13 @@ import { flow, lessThanOrEqual, strictEquals } from "./fns.ts";
  * Ord
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#ord
  */
-export interface Ord<T> extends Setoid<T> {
+export type Ord<T> = Setoid<T> & {
   readonly lte: (a: T) => (b: T) => boolean;
-}
+};
 
 export type Ordering = -1 | 0 | 1;
 
-export type Compare<A> = Fn<[A, A], Ordering>;
+export type Compare<A> = (left: A, right: A) => Ordering;
 
 export const ordString: Ord<string> = {
   equals: strictEquals,

--- a/predicate.ts
+++ b/predicate.ts
@@ -1,0 +1,96 @@
+import * as __ from "./kind.ts";
+import type * as T from "./types.ts";
+
+import { flow } from "./fns.ts";
+
+// ---
+// Types
+// ---
+
+/**
+ * The Predicate<A> type is a function that takes some
+ * value of type A and returns boolean, indicating
+ * that a property is true or false for the value A.
+ *
+ * @example
+ * ```ts
+ * import type { Predicate } from "./predicate.ts";
+ * import * as O from "./option.ts";
+ *
+ * function fromPredicate<A>(predicate: Predicate<A>) {
+ *   return (a: A): O.Option<A> => predicate(a)
+ *     ? O.some(a) : O.none;
+ * }
+ *
+ * function isPositive(n: number): boolean {
+ *   return n > 0;
+ * }
+ *
+ * const isPos = fromPredicate(isPositive);
+ *
+ * const resultSome = isPos(1); // Some(1)
+ * const resultNone = isPos(-1); // None
+ * ```
+ *
+ * @since 2.0.0
+ */
+export type Predicate<A> = (a: A) => boolean;
+
+export const URI = "Predicate";
+
+export type URI = typeof URI;
+
+declare module "./kind.ts" {
+  // deno-lint-ignore no-explicit-any
+  export interface Kinds<_ extends any[]> {
+    [URI]: Predicate<_[0]>;
+  }
+}
+
+// ---
+// Combinators
+// ---
+
+export function contramap<I, A>(
+  fia: (i: I) => A,
+): (ua: Predicate<A>) => Predicate<I> {
+  return (ua) => flow(fia, ua);
+}
+
+export function not<A>(predicate: Predicate<A>): Predicate<A> {
+  return (a) => !predicate(a);
+}
+
+export function or<A>(right: Predicate<A>) {
+  return (left: Predicate<A>): Predicate<A> => (a) => left(a) || right(a);
+}
+
+export function and<A>(right: Predicate<A>) {
+  return (left: Predicate<A>): Predicate<A> => (a) => left(a) && right(a);
+}
+
+// ---
+// Instances
+// ---
+
+export const Contravariant: T.Contravariant<URI> = { contramap };
+
+// ---
+// Instance Getters
+// ---
+
+export function getSemigroupAny<A = never>(): T.Semigroup<Predicate<A>> {
+  return { concat: or };
+}
+
+export function getSemigroupAll<A = never>(): T.Semigroup<Predicate<A>> {
+  return { concat: and };
+}
+
+export function getMonoidAny<A = never>(): T.Monoid<Predicate<A>> {
+  return { concat: or, empty: () => () => false };
+}
+
+export function getMonoidAll<A = never>(): T.Monoid<Predicate<A>> {
+  return { concat: and, empty: () => () => true };
+}

--- a/prism.ts
+++ b/prism.ts
@@ -1,6 +1,7 @@
-import type { Kind, URIS } from "./kind.ts";
-import type { Predicate, Refinement } from "./types.ts";
 import type * as T from "./types.ts";
+import type { Kind, URIS } from "./kind.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 
 import type { Optic } from "./optic.ts";
 import type { Iso } from "./iso.ts";

--- a/refinement.ts
+++ b/refinement.ts
@@ -1,0 +1,31 @@
+import type { Option } from "./option.ts";
+import type { Either } from "./either.ts";
+
+export type Refinement<A, B extends A> = (a: A) => a is B;
+
+export function fromOption<A, B extends A>(
+  faob: (a: A) => Option<B>,
+): Refinement<A, B> {
+  return (a: A): a is B => faob(a).tag === "Some";
+}
+
+export function fromEither<A, B extends A>(
+  faob: (a: A) => Either<unknown, B>,
+): Refinement<A, B> {
+  return (a: A): a is B => faob(a).tag === "Right";
+}
+
+export function or<A, C extends A>(right: Refinement<A, C>) {
+  return <B extends A>(left: Refinement<A, B>): Refinement<A, B | C> =>
+  (a: A): a is B | C => left(a) || right(a);
+}
+
+export function and<A, C extends A>(right: Refinement<A, C>) {
+  return <B extends A>(left: Refinement<A, B>): Refinement<A, B & C> =>
+  (a: A): a is B & C => left(a) && right(a);
+}
+
+export function compose<A, B extends A, C extends B>(right: Refinement<B, C>) {
+  return (left: Refinement<A, B>): Refinement<A, C> => (a: A): a is C =>
+    left(a) && right(a);
+}

--- a/set.ts
+++ b/set.ts
@@ -1,5 +1,5 @@
 import type { Kind, URIS } from "./kind.ts";
-import type { Predicate } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
 import type * as T from "./types.ts";
 
 import { flow, pipe } from "./fns.ts";

--- a/testing/assert.ts
+++ b/testing/assert.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.77.0/testing/asserts.ts";
 
 import type * as T from "../types.ts";
-import type { Predicate } from "../types.ts";
+import type { Predicate } from "../predicate.ts";
 import type { Kind, URIS } from "../kind.ts";
 
 import { apply, flow, pipe } from "../fns.ts";

--- a/testing/fns.test.ts
+++ b/testing/fns.test.ts
@@ -7,24 +7,6 @@ import {
 import * as F from "../fns.ts";
 import { zip } from "../array.ts";
 
-Deno.test("fns isNotNil", () => {
-  assertEquals(F.isNotNil(undefined), false);
-  assertEquals(F.isNotNil(null), false);
-  assertEquals(F.isNotNil(1), true);
-  assertEquals(F.isNotNil(0), true);
-  assertEquals(F.isNotNil("Hello"), true);
-  assertEquals(F.isNotNil(""), true);
-});
-
-Deno.test("fns isNil", () => {
-  assertEquals(F.isNil(undefined), true);
-  assertEquals(F.isNil(null), true);
-  assertEquals(F.isNil(1), false);
-  assertEquals(F.isNil(0), false);
-  assertEquals(F.isNil("Hello"), false);
-  assertEquals(F.isNil(""), false);
-});
-
 Deno.test("fns isRecord", () => {
   assertEquals(F.isRecord(null), false);
   assertEquals(F.isRecord(undefined), false);

--- a/traversal.ts
+++ b/traversal.ts
@@ -1,6 +1,7 @@
 import type * as T from "./types.ts";
 import type { Kind, URIS } from "./kind.ts";
-import type { Predicate, Refinement } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
+import type { Refinement } from "./refinement.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
 

--- a/types.ts
+++ b/types.ts
@@ -1,149 +1,191 @@
 /**
- * Re-exports of algebraic structures
+ * Types is the mod.ts file for all type classes
+ * in fun. It also contains useful types that don't
+ * belong anywhere else in fun.
  */
 
+/**
+ * Reexport of Alt type
+ */
 export type { Alt } from "./alt.ts";
 
+/**
+ * Reexport of Alternative type
+ */
 export type { Alternative } from "./alternative.ts";
 
+/**
+ * Reexport of Applicative type
+ */
 export type { Applicative } from "./applicative.ts";
 
+/**
+ * Reexport of Apply type
+ */
 export type { Apply } from "./apply.ts";
 
+/**
+ * Reexport of Bifunctor type
+ */
 export type { Bifunctor } from "./bifunctor.ts";
 
+/**
+ * Reexport of Category type
+ */
 export type { Category } from "./category.ts";
 
+/**
+ * Reexport of Chain type
+ */
 export type { Chain } from "./chain.ts";
 
+/**
+ * Reexport of Comonad type
+ */
 export type { Comonad } from "./comonad.ts";
 
+/**
+ * Reexport of Contravariant type
+ */
 export type { Contravariant } from "./contravariant.ts";
 
+/**
+ * Reexport of Extend type
+ */
 export type { Extend } from "./extend.ts";
 
+/**
+ * Reexport of Filterable type
+ */
 export type { Filterable } from "./filterable.ts";
 
+/**
+ * Reexport of Foldable type
+ */
 export type { Foldable } from "./foldable.ts";
 
+/**
+ * Reexport of Functor type
+ */
 export type { Functor } from "./functor.ts";
 
+/**
+ * Reexport of Group type
+ */
 export type { Group } from "./group.ts";
 
+/**
+ * Reexport of Monad and MonadThrow types
+ */
 export type { Monad, MonadThrow } from "./monad.ts";
 
+/**
+ * Reexport of Monoid type
+ */
 export type { Monoid } from "./monoid.ts";
 
+/**
+ * Reexport of Ord type
+ */
 export type { Ord } from "./ord.ts";
 
+/**
+ * Reexport of Plus type
+ */
 export type { Plus } from "./plus.ts";
 
+/**
+ * Reexport of Profunctor type
+ */
 export type { Profunctor } from "./profunctor.ts";
 
+/**
+ * Reexport of Schemable type
+ */
 export type { Schemable } from "./schemable.ts";
 
+/**
+ * Reexport of Semigroup type
+ */
 export type { Semigroup } from "./semigroup.ts";
 
+/**
+ * Reexport of Semigroupoid type
+ */
 export type { Semigroupoid } from "./semigroupoid.ts";
 
+/**
+ * Reexport of Setoid type
+ */
 export type { Setoid } from "./setoid.ts";
 
+/**
+ * Reexport of Show type
+ */
 export type { Show } from "./show.ts";
 
+/**
+ * Reexport of Traversable type
+ */
 export type { Traversable } from "./traversable.ts";
 
 /**
- * String representations of primitive values as returned by typeof
- */
-export type ConstPrimitive =
-  | "string"
-  | "number"
-  | "bigint"
-  | "boolean"
-  | "symbol"
-  | "undefined"
-  | "object"
-  | "function";
-
-/**
- * Fn Type
+ * NonEmptyRecord<R> is a bounding type that will will
+ * return a type level never if the type value of R is
+ * either not a record is is a record without any
+ * index or key values.
  *
- * Represents a function with arbitrary arity of arguments
- */
-export type Fn<AS extends unknown[], B> = (...as: AS) => B;
-
-/**
- * UnknownFn Type
+ * @example
+ * ```
+ * import type { NonEmptyRecord } from "./types.ts";
  *
- * Represents a function with unknown unputs and output
- */
-export type UnknownFn = Fn<unknown[], unknown>;
-
-/**
- * Nil Type
+ * function doSomething<R>(_: NonEmptyRecord<R>): void {
+ *   return undefined;
+ * }
  *
- * An alias for undefined | null
- */
-export type Nil = undefined | null;
-
-/**
- * Predicate<A>
+ * const result = doSomething({ one: 1 }); // This is ok
+ * // const result2 = doSomethign({}); // This is a type error
+ * ```
  *
- * An alias for a function that takes type A and returns a boolean
- */
-export type Predicate<A> = Fn<[A], boolean>;
-
-/**
- * Guard<A>
- *
- * An alias for the TypeScript type guard function
- */
-export type Guard<A> = (a: unknown) => a is A;
-
-/**
- * Refinement<A, B extends A>
- *
- * An alias for a function that takes an A type and refines it to a B type
- */
-export type Refinement<A, B extends A> = (a: A) => a is B;
-
-/**
- * Ordering Type
- *
- * Ordering is a type alias for -1 | 0 | 1 consts
- */
-export type Ordering = -1 | 0 | 1;
-
-/**
- * NonEmptyRecord<R>
- *
- * NonEmptyRecord<R> returns R only if it has properties, otherwise it
- * coerces to never. When used in the argument position this forces a generic
- * to have keys.
+ * @since 2.0.0
  */
 export type NonEmptyRecord<R> = keyof R extends never ? never : R;
 
-export type NonEmptyArray<A> = [A, ...A[]];
-
 /**
- * Return
+ * Args is an extraction type over functions. Given any function
+ * type it will return a tuple type of all of the functions
+ * argument types in order.
  *
- * Extracts the return type of a function type
- */
-// deno-lint-ignore no-explicit-any
-export type Return<T> = T extends (...as: any[]) => infer R ? R : never;
-
-/**
- * Args
+ * @example
+ * ```ts
+ * import type { Args } from "./types.ts";
  *
- * Extracts the argument types of a function type
+ * function _doSomething(n: number, s: string): number {
+ *   return n + s.length;
+ * }
+ *
+ * type args = Args<typeof _doSomething>; // [number, string]
+ * ```
+ *
+ * @since 2.0.0
  */
 // deno-lint-ignore no-explicit-any
 export type Args<T> = T extends (...as: infer AS) => any ? AS : never;
 
 /**
- * Or
+ * Return is an extraction type over functions. Given any function
+ * type it will output the return type of that function.
  *
- * Replaces a type A with B if B doesn't extend never;
+ * @example
+ * ```ts
+ * import type { Return } from "./types.ts";
+ *
+ * type SomeFunc = (n: number, s: string) => Record<string, boolean>;
+ *
+ * type result = Return<SomeFunc>; // Record<string, boolean>;
+ * ```
+ *
+ * @since 2.0.0
  */
-export type Or<A, B> = B extends never ? A : B;
+// deno-lint-ignore no-explicit-any
+export type Return<T> = T extends (...as: any[]) => infer R ? R : never;


### PR DESCRIPTION
* types.ts: remove Predicate, Refinement, NonEmptyArray, Fn, UnknownFn, ConstPrimitive, and Ordering.
* types.ts: updated all type references to new files or typed in place.
* predicate.ts: move Predicate out of types.ts and implemented various tooling
* refinement.ts: move Refinement out of types.ts and implemented various tooling
* fns.ts: remove isNil and isNotNil and updated all refs

Fixes #130