### PR TITLE
feat: try out the matech hkt implementation

### DIFF
--- a/alt.ts
+++ b/alt.ts
@@ -6,9 +6,8 @@
  * "If this one doesn't work, try this other one".
  */
 
-// deno-lint-ignore-file no-explicit-any
 import type { Functor } from "./functor.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * An instance of Alt extends Functor and provides a new method
@@ -27,10 +26,10 @@ import type { Kind, URIS } from "./kind.ts";
  * The original type came from
  * [here](https://github.com/fantasyland/static-land/blob/master/docs/spec.md#alt)
  */
-export type Alt<URI extends URIS, _ extends any[] = any[]> =
-  & Functor<URI, _>
+export type Alt<U extends Kind> =
+  & Functor<U>
   & {
-    readonly alt: <A, B extends _[0], C extends _[1], D extends _[2]>(
-      right: Kind<URI, [A, B, C, D]>,
-    ) => (left: Kind<URI, [A, B, C, D]>) => Kind<URI, [A, B, C, D]>;
+    readonly alt: <A, B, C, D>(
+      right: $<U, [A, B, C, D]>,
+    ) => (left: $<U, [A, B, C, D]>) => $<U, [A, B, C, D]>;
   };

--- a/alternative.ts
+++ b/alternative.ts
@@ -1,5 +1,4 @@
-//deno-lint-ignore-file no-explicit-any
-import type { URIS } from "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type { Applicative } from "./applicative.ts";
 import type { Plus } from "./plus.ts";
 
@@ -7,5 +6,4 @@ import type { Plus } from "./plus.ts";
  * Alternative
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#alternative
  */
-export interface Alternative<URI extends URIS, _ extends any[] = any[]>
-  extends Applicative<URI, _>, Plus<URI, _> {}
+export type Alternative<U extends Kind> = Applicative<U> & Plus<U>;

--- a/applicative.ts
+++ b/applicative.ts
@@ -1,19 +1,10 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Apply } from "./apply.ts";
 
 /**
  * Applicative
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#applicative
  */
-export interface Applicative<URI extends URIS, _ extends any[] = any[]>
-  extends Apply<URI, _> {
-  readonly of: <
-    A,
-    B extends _[0] = never,
-    C extends _[1] = never,
-    D extends _[2] = never,
-  >(
-    a: A,
-  ) => Kind<URI, [A, B, C, D]>;
+export interface Applicative<U extends Kind> extends Apply<U> {
+  readonly of: <A, B, C, D>(a: A) => $<U, [A, B, C, D]>;
 }

--- a/array.ts
+++ b/array.ts
@@ -1,4 +1,4 @@
-import { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Separated } from "./separated.ts";
 import type { Option } from "./option.ts";
@@ -11,18 +11,11 @@ import { apply, flow, identity, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 import { Ord, toCompare } from "./ord.ts";
 
-export type TypeOf<T> = T extends ReadonlyArray<infer A> ? A : never;
-
-export const URI = "Array";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: ReadonlyArray<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: ReadonlyArray<this[0]>;
 }
+
+export type TypeOf<T> = T extends ReadonlyArray<infer A> ? A : never;
 
 export function empty<A = never>(): ReadonlyArray<A> {
   return [];
@@ -207,18 +200,11 @@ export function filter<A>(
   };
 }
 
-// deno-lint-ignore no-explicit-any
-export function traverse<VRI extends URIS, _ extends any[] = any[]>(
-  A: T.Applicative<VRI, _>,
-): <
-  A,
-  I,
-  J extends _[0] = never,
-  K extends _[1] = never,
-  L extends _[2] = never,
->(
-  favi: (a: A, i: number) => Kind<VRI, [I, J, K, L]>,
-) => (ta: ReadonlyArray<A>) => Kind<VRI, [ReadonlyArray<I>, J, K, L]> {
+export function traverse<V extends Kind>(
+  A: T.Applicative<V>,
+): <A, I, J, K, L>(
+  favi: (a: A, i: number) => $<V, [I, J, K, L]>,
+) => (ta: ReadonlyArray<A>) => $<V, [ReadonlyArray<I>, J, K, L]> {
   return (favi) =>
     reduce(
       (vis, a, index) =>
@@ -503,11 +489,11 @@ export function getMonoid<A = never>(): T.Monoid<ReadonlyArray<A>> {
   });
 }
 
-export const createSequence = <VRI extends URIS>(
-  A: T.Applicative<VRI>,
+export const createSequence = <V extends Kind>(
+  A: T.Applicative<V>,
 ): <A, B, C, D>(
-  ta: Kind<VRI, [A, B, C, D]>[],
-) => Kind<VRI, [ReadonlyArray<A>, B, C, D]> => {
+  ta: $<V, [A, B, C, D]>[],
+) => $<V, [ReadonlyArray<A>, B, C, D]> => {
   // deno-lint-ignore no-explicit-any
   return pipe(A.map(identity), traverse(A)) as any;
 };

--- a/async_iterable.ts
+++ b/async_iterable.ts
@@ -1,19 +1,12 @@
 import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
-import type { Predicate } from "./types.ts";
+import type { Predicate } from "./predicate.ts";
 
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 import { wait } from "./fns.ts";
 
-export const URI = "AsyncIterable";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: AsyncIterable<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: AsyncIterable<this[0]>;
 }
 
 const isAsyncIterator = <A>(

--- a/bifunctor.ts
+++ b/bifunctor.ts
@@ -1,21 +1,16 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * Bifunctor
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#bifunctor
  */
-export interface Bifunctor<URI extends URIS, _ extends any[] = any[]> {
-  readonly bimap: <A, B extends _[0], I, J>(
+export interface Bifunctor<U extends Kind> {
+  readonly bimap: <A, B, I, J>(
     fbj: (b: B) => J,
     fai: (a: A) => I,
-  ) => <C extends _[1], D extends _[2]>(
-    tab: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [I, J, C, D]>;
+  ) => <C, D>(tab: $<U, [A, B, C, D]>) => $<U, [I, J, C, D]>;
 
-  readonly mapLeft: <B extends _[0], J>(
+  readonly mapLeft: <B, J>(
     fbj: (b: B) => J,
-  ) => <A, C extends _[1], D extends _[2]>(
-    tea: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A, J, C, D]>;
+  ) => <A, C, D>(tea: $<U, [A, B, C, D]>) => $<U, [A, J, C, D]>;
 }

--- a/chain.ts
+++ b/chain.ts
@@ -1,14 +1,12 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Apply } from "./apply.ts";
 
 /**
  * Chain
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#chain
  */
-export interface Chain<URI extends URIS, _ extends any[] = any[]>
-  extends Apply<URI, _> {
-  readonly chain: <A, I, B extends _[0], C extends _[1], D extends _[2]>(
-    fati: (a: A) => Kind<URI, [I, B, C, D]>,
-  ) => (ta: Kind<URI, [A, B, C, D]>) => Kind<URI, [I, B, C, D]>;
+export interface Chain<U extends Kind> extends Apply<U> {
+  readonly chain: <A, I, B, C, D>(
+    fati: (a: A) => $<U, [I, B, C, D]>,
+  ) => (ta: $<U, [A, B, C, D]>) => $<U, [I, B, C, D]>;
 }

--- a/comonad.ts
+++ b/comonad.ts
@@ -1,14 +1,10 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Extend } from "./extend.ts";
 
 /**
  * Comonad
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#comonad
  */
-export interface Comonad<URI extends URIS, _ extends any[] = any[]>
-  extends Extend<URI, _> {
-  readonly extract: <A, B extends _[0], C extends _[1], D extends _[2]>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => A;
+export interface Comonad<U extends Kind> extends Extend<U> {
+  readonly extract: <A, B, C, D>(ta: $<U, [A, B, C, D]>) => A;
 }

--- a/const.ts
+++ b/const.ts
@@ -5,15 +5,12 @@ import { identity } from "./fns.ts";
 
 export type Const<E, _ = never> = E;
 
-export const URI = "Const";
+export interface URI extends Kind {
+  readonly type: Const<this[1], this[0]>;
+}
 
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Const<_[1], _[0]>;
-  }
+export interface RightURI<B> extends Kind {
+  readonly type: Const<B, this[0]>;
 }
 
 export function make<E, A = never>(e: E): Const<E, A> {
@@ -65,7 +62,7 @@ export const getMonoid: <E, A>(
 
 export const getApply = <E>(
   S: T.Semigroup<E>,
-): T.Apply<URI, [E]> => ({
+): T.Apply<RightURI<E>> => ({
   map: (_) => (ta) => ta,
   // deno-lint-ignore no-explicit-any
   ap: (tfai) => (ta): Const<any, any> => make(S.concat(ta)(tfai)),
@@ -73,7 +70,7 @@ export const getApply = <E>(
 
 export const getApplicative = <E>(
   M: T.Monoid<E>,
-): T.Applicative<URI, [E]> => ({
+): T.Applicative<RightURI<E>> => ({
   // deno-lint-ignore no-explicit-any
   of: (): Const<any, any> => make(M.empty()),
   ...getApply(M),

--- a/contravariant.ts
+++ b/contravariant.ts
@@ -1,14 +1,11 @@
-// deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * Contravariant
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#contravariant
  */
-export interface Contravariant<URI extends URIS, _ extends any[] = any[]> {
+export interface Contravariant<U extends Kind> {
   readonly contramap: <I, A>(
     fia: (i: I) => A,
-  ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    ua: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [I, B, C, D]>;
+  ) => <B, C, D>(ua: $<U, [A, B, C, D]>) => $<U, [I, B, C, D]>;
 }

--- a/datum.ts
+++ b/datum.ts
@@ -1,4 +1,4 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import { isNotNil } from "./nilable.ts";
@@ -31,15 +31,8 @@ export type Some<A> = Refresh<A> | Replete<A>;
 
 export type Loading<A> = Pending | Refresh<A>;
 
-export const URI = "Datum";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Datum<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Datum<this[0]>;
 }
 
 export const initial: Initial = { tag: "Initial" };
@@ -183,11 +176,11 @@ export function reduce<A, O>(
   return (ta) => isSome(ta) ? foao(o, ta.value) : o;
 }
 
-export function traverse<VRI extends URIS>(
-  A: T.Applicative<VRI>,
+export function traverse<V extends Kind>(
+  A: T.Applicative<V>,
 ): <A, I, J, K, L>(
-  favi: (a: A) => Kind<VRI, [I, J, K, L]>,
-) => (ta: Datum<A>) => Kind<VRI, [Datum<I>, J, K, L]> {
+  favi: (a: A) => $<V, [I, J, K, L]>,
+) => (ta: Datum<A>) => $<V, [Datum<I>, J, K, L]> {
   return (favi) =>
     fold(
       () => A.of(constInitial()),

--- a/decode_error.ts
+++ b/decode_error.ts
@@ -1,10 +1,10 @@
 import type * as T from "./types.ts";
-import type { Forest, Tree } from "./tree.ts";
+import type { Forest } from "./tree.ts";
 
 import * as TR from "./tree.ts";
 import * as A from "./array.ts";
 import * as O from "./option.ts";
-import { pipe, todo } from "./fns.ts";
+import { pipe } from "./fns.ts";
 
 export const required = "required" as const;
 

--- a/decoder.ts
+++ b/decoder.ts
@@ -1,4 +1,4 @@
-import type * as __ from "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Either } from "./either.ts";
 import type { DecodeError } from "./decode_error.ts";
@@ -36,7 +36,7 @@ export function extract<A>(ta: Decoded<A>): Either<string, A> {
 
 const MonadDecoded = E.getRightMonad(DE.Semigroup);
 
-const ApplicativeDecoded: T.Applicative<E.URI, [DecodeError]> = MonadDecoded;
+const ApplicativeDecoded: T.Applicative<E.RightURI<DecodeError>> = MonadDecoded;
 
 const traverseRecord = R.traverse(ApplicativeDecoded);
 
@@ -52,15 +52,8 @@ export type From<T> = T extends Decoder<infer _, infer A> ? A : never;
 
 export type To<T> = T extends Decoder<infer B, infer _> ? B : never;
 
-export const URI = "Decoder";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Decoder<unknown, _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Decoder<unknown, this[0]>;
 }
 
 // Internal Helpers

--- a/extend.ts
+++ b/extend.ts
@@ -1,14 +1,12 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Functor } from "./functor.ts";
 
 /**
  * Extend
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#extend
  */
-export interface Extend<URI extends URIS, _ extends any[] = any[]>
-  extends Functor<URI, _> {
-  readonly extend: <A, I, B extends _[0], C extends _[1], D extends _[2]>(
-    ftai: (t: Kind<URI, [A, B, C, D]>) => I,
-  ) => (ta: Kind<URI, [A, B, C, D]>) => Kind<URI, [I, B, C, D]>;
+export interface Extend<U extends Kind> extends Functor<U> {
+  readonly extend: <A, I, B, C, D>(
+    ftai: (t: $<U, [A, B, C, D]>) => I,
+  ) => (ta: $<U, [A, B, C, D]>) => $<U, [I, B, C, D]>;
 }

--- a/filterable.ts
+++ b/filterable.ts
@@ -1,5 +1,4 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Predicate } from "./predicate.ts";
 
 /**
@@ -8,10 +7,8 @@ import type { Predicate } from "./predicate.ts";
  *
  * TODO; add refine method
  */
-export interface Filterable<URI extends URIS, _ extends any[] = any[]> {
+export interface Filterable<U extends Kind> {
   readonly filter: <A>(
     predicate: Predicate<A>,
-  ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A, B, C, D]>;
+  ) => <B, C, D>(ta: $<U, [A, B, C, D]>) => $<U, [A, B, C, D]>;
 }

--- a/fns.ts
+++ b/fns.ts
@@ -1,5 +1,3 @@
-// deno-lint-ignore-file no-explicit-any
-
 /**
  * handleThrow
  *
@@ -280,7 +278,7 @@ export function recover<A>(
  * conversion between two types.
  */
 export function unsafeCoerce<A, B>(a: A): B {
-  return a as any;
+  return a as unknown as B;
 }
 
 /**
@@ -489,7 +487,9 @@ export function flow<
 ): (...a: A) => J;
 export function flow<AS extends unknown[], B>(
   a: (...as: AS) => B,
-  ...fns: ((_: any) => any)[]
+  ...fns: ((_: unknown) => unknown)[]
 ): (...as: AS) => unknown {
-  return (...args: AS): unknown => fns.reduce(apply1, a(...args));
+  return (...args: AS): unknown =>
+    // deno-lint-ignore no-explicit-any
+    fns.reduce((a, fab): any => fab(a), a(...args));
 }

--- a/foldable.ts
+++ b/foldable.ts
@@ -1,15 +1,12 @@
-//deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * Foldable
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#foldable
  */
-export interface Foldable<URI extends URIS, _ extends any[] = any[]> {
+export interface Foldable<U extends Kind> {
   readonly reduce: <A, O>(
     foao: (o: O, a: A) => O,
     o: O,
-  ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => O;
+  ) => <B, C, D>(ta: $<U, [A, B, C, D]>) => O;
 }

--- a/functor.ts
+++ b/functor.ts
@@ -1,14 +1,11 @@
-// deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * Functor
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#functor
  */
-export interface Functor<URI extends URIS, _ extends any[] = any[]> {
+export interface Functor<U extends Kind> {
   readonly map: <A, I>(
     fai: (a: A) => I,
-  ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [I, B, C, D]>;
+  ) => <B, C, D>(ta: $<U, [A, B, C, D]>) => $<U, [I, B, C, D]>;
 }

--- a/guard.ts
+++ b/guard.ts
@@ -1,4 +1,4 @@
-import type * as __ from "./kind.ts";
+import type { Kind } from "./kind.ts";
 
 import { isNil } from "./nilable.ts";
 import * as S from "./schemable.ts";
@@ -9,15 +9,8 @@ export type TypeOf<T> = T extends Guard<infer _, infer A> ? A : never;
 
 export type InputOf<T> = T extends Guard<infer B, infer _> ? B : never;
 
-export const URI = "Guard";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Guard<unknown, _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Guard<unknown, this[0]>;
 }
 
 export function compose<A, B extends A, C extends B>(

--- a/identity.ts
+++ b/identity.ts
@@ -3,15 +3,8 @@ import type * as T from "./types.ts";
 
 export type Identity<A> = A;
 
-export const URI = "Identity";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Identity<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Identity<this[0]>;
 }
 
 export function of<A>(a: A): Identity<A> {

--- a/io.ts
+++ b/io.ts
@@ -1,4 +1,4 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import {
@@ -10,15 +10,8 @@ import { apply, constant, flow, pipe } from "./fns.ts";
 
 export type IO<A> = () => A;
 
-export const URI = "IO";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: IO<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: IO<this[0]>;
 }
 
 export function of<A>(a: A): IO<A> {
@@ -52,11 +45,11 @@ export function reduce<A, O>(
   return (ta) => foao(o, ta());
 }
 
-export function traverse<VRI extends URIS>(
-  A: T.Applicative<VRI>,
+export function traverse<V extends Kind>(
+  A: T.Applicative<V>,
 ): <A, I, J, K, L>(
-  faui: (a: A) => Kind<VRI, [I, J, K, L]>,
-) => (ta: IO<A>) => Kind<VRI, [IO<I>, J, K, L]> {
+  faui: (a: A) => $<V, [I, J, K, L]>,
+) => (ta: IO<A>) => $<V, [IO<I>, J, K, L]> {
   return (faui) => (ta) => pipe(faui(ta()), A.map(of));
 }
 

--- a/io_either.ts
+++ b/io_either.ts
@@ -8,15 +8,8 @@ import { constant, flow, identity, pipe } from "./fns.ts";
 
 export type IOEither<L, R> = I.IO<E.Either<L, R>>;
 
-export const URI = "IOEither";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: IOEither<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: IOEither<this[1], this[0]>;
 }
 
 export function left<A = never, B = never>(left: B): IOEither<B, A> {

--- a/iso.ts
+++ b/iso.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
 import type { Predicate } from "./predicate.ts";
@@ -194,10 +194,10 @@ export function prop<A, P extends keyof A>(
   return flow(asLens, lensProp(prop));
 }
 
-export function traverse<URI extends URIS>(
-  T: T.Traversable<URI>,
+export function traverse<U extends Kind>(
+  T: T.Traversable<U>,
 ): <S, A, B = never, C = never, D = never>(
-  sa: Iso<S, Kind<URI, [A, B, C, D]>>,
+  sa: Iso<S, $<U, [A, B, C, D]>>,
 ) => Traversal<S, A> {
   const _traversal = toTraversal(T);
   return (sa) => composeTraversal(sa, _traversal());

--- a/iterable.ts
+++ b/iterable.ts
@@ -3,15 +3,8 @@ import type * as T from "./types.ts";
 
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 
-export const URI = "Iterable";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Iterable<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Iterable<this[0]>;
 }
 
 const isIterator = <A>(

--- a/kind.ts
+++ b/kind.ts
@@ -1,25 +1,17 @@
-// deno-lint-ignore-file no-explicit-any
-
 /**
- * A registry for Kind URIS with their substitution strategies. _ represents
- * a tuple of types used to fill a specific Kind.
- *
- * Note that the idiomatic replacement type for kinds uses _[0] as the inner-
- * most hole for Functor, Apply, Chain, etc. Thus Either<L, R> should use the
- * hole order of Either<_[1], _[0]>, Reader<R, A> should use Reader<_[1], _[0]>,
- * etc.
+ * Kind is an interface that can be extended
+ * to retrieve inner types using "this"
  */
-export interface Kinds<_ extends any[]> {
-  "_": _;
+export interface Kind {
+  readonly [index: number]: unknown;
+  readonly type?: unknown;
 }
 
 /**
- * A union of all Kind URIS, used primarily to ensure that a Kind is registered
- * before it is used to construct an instance.
+ * $ is a substitution type, takeing a Kind implementation T and
+ * substituting inenr types as defined by the evaluation of T
+ * with the values in S
  */
-export type URIS = keyof Kinds<any[]>;
-
-/**
- * Lookup the kind at URI and substitute with the values in _.
- */
-export type Kind<URI extends URIS, _ extends any[] = never[]> = Kinds<_>[URI];
+export type $<T extends Kind, S extends unknown> = T extends
+  { readonly type: unknown } ? (T & S)["type"]
+  : { readonly T: T; readonly S: S };

--- a/lens.ts
+++ b/lens.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
 import type { Predicate } from "./predicate.ts";
@@ -64,7 +64,7 @@ export function atRecord<A = never>(): At<
 
 export function atMap<A, B>(
   setoid: T.Setoid<B>,
-): At<Map<B, A>, B, Option<A>> {
+): At<ReadonlyMap<B, A>, B, Option<A>> {
   const _lookup = M.lookup(setoid);
   const _deleteAt = M.deleteAt(setoid);
   const _insertAt = M.insertAt(setoid);
@@ -219,10 +219,10 @@ export function map<A, B>(
   return (sa) => lens(flow(sa.get, ab), flow(ba, sa.set));
 }
 
-export function traverse<URI extends URIS>(
-  T: T.Traversable<URI>,
+export function traverse<U extends Kind>(
+  T: T.Traversable<U>,
 ): <S, A, B = never, C = never, D = never>(
-  sa: Lens<S, Kind<URI, [A, B, C, D]>>,
+  sa: Lens<S, $<U, [A, B, C, D]>>,
 ) => Traversal<S, A> {
   const _traversal = toTraversal(T);
   return (sa) => composeTraversal(sa, _traversal());

--- a/map.ts
+++ b/map.ts
@@ -1,4 +1,4 @@
-import type * as __ from "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Option } from "./option.ts";
 
@@ -8,34 +8,29 @@ import { toCompare } from "./ord.ts";
 import { fromEquals } from "./setoid.ts";
 import { flow, pipe } from "./fns.ts";
 
-export const URI = "Map";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Map<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: ReadonlyMap<this[1], this[0]>;
 }
 
-export function zero(): Map<never, never> {
+export function zero(): ReadonlyMap<never, never> {
   return new Map<never, never>();
 }
 
-export function empty<K, A>(): Map<K, A> {
+export function empty<K, A>(): ReadonlyMap<K, A> {
   return new Map();
 }
 
-export function singleton<K, A>(k: K, a: A): Map<K, A> {
+export function singleton<K, A>(k: K, a: A): ReadonlyMap<K, A> {
   return new Map([[k, a]]);
 }
 
-export function isEmpty<A, B>(ta: Map<B, A>): boolean {
+export function isEmpty<A, B>(ta: ReadonlyMap<B, A>): boolean {
   return ta.size === 0;
 }
 
-export function map<A, I>(fai: (a: A) => I): <B>(ta: Map<B, A>) => Map<B, I> {
+export function map<A, I>(
+  fai: (a: A) => I,
+): <B>(ta: ReadonlyMap<B, A>) => ReadonlyMap<B, I> {
   return (ta) => {
     const tb = new Map();
     for (const [k, a] of ta) {
@@ -48,7 +43,7 @@ export function map<A, I>(fai: (a: A) => I): <B>(ta: Map<B, A>) => Map<B, I> {
 export function bimap<A, B, I, J>(
   fbj: (b: B) => J,
   fai: (a: A) => I,
-): (ta: Map<B, A>) => Map<J, I> {
+): (ta: ReadonlyMap<B, A>) => ReadonlyMap<J, I> {
   return (ta) => {
     const tb = new Map();
     for (const [b, a] of ta) {
@@ -60,7 +55,7 @@ export function bimap<A, B, I, J>(
 
 export function mapLeft<B, J>(
   fbj: (b: B) => J,
-): <A>(ta: Map<B, A>) => Map<J, A> {
+): <A>(ta: ReadonlyMap<B, A>) => ReadonlyMap<J, A> {
   return (ta) => {
     const tb = new Map();
     for (const [b, a] of ta) {
@@ -70,13 +65,13 @@ export function mapLeft<B, J>(
   };
 }
 
-export function size<K, A>(d: Map<K, A>): number {
+export function size<K, A>(d: ReadonlyMap<K, A>): number {
   return d.size;
 }
 
 export function lookupWithKey<K>(
   S: T.Setoid<K>,
-): (k: K) => <A>(ta: Map<K, A>) => Option<[K, A]> {
+): (k: K) => <A>(ta: ReadonlyMap<K, A>) => Option<[K, A]> {
   return (k) => (ta) => {
     for (const [ka, a] of ta.entries()) {
       if (S.equals(ka)(k)) {
@@ -89,7 +84,7 @@ export function lookupWithKey<K>(
 
 export function lookup<K>(
   S: T.Setoid<K>,
-): (k: K) => <A>(ta: Map<K, A>) => Option<A> {
+): (k: K) => <A>(ta: ReadonlyMap<K, A>) => Option<A> {
   const _lookupWithKey = lookupWithKey(S);
   return (k) => {
     const lookupWithKeyE = _lookupWithKey(k);
@@ -104,14 +99,14 @@ export function lookup<K>(
 
 export function member<K>(
   S: T.Setoid<K>,
-): (k: K) => <A>(ta: Map<K, A>) => boolean {
+): (k: K) => <A>(ta: ReadonlyMap<K, A>) => boolean {
   const lookupKey = lookup(S);
   return (k) => (m) => pipe(lookupKey(k)(m), O.isSome);
 }
 
 export function elem<A>(
   S: T.Setoid<A>,
-): (a: A) => <K>(m: Map<K, A>) => boolean {
+): (a: A) => <K>(m: ReadonlyMap<K, A>) => boolean {
   return (a) => {
     const eq = S.equals(a);
     return (ta) => {
@@ -127,25 +122,27 @@ export function elem<A>(
 
 export function entries<B>(
   O: T.Ord<B>,
-): <A>(ta: Map<B, A>) => ReadonlyArray<[B, A]> {
+): <A>(ta: ReadonlyMap<B, A>) => ReadonlyArray<[B, A]> {
   const _compare = toCompare(O);
   return (ta) =>
     Array.from(ta.entries()).sort(([left], [right]) => _compare(left, right));
 }
 
-export function keys<K>(O: T.Ord<K>): <A>(ta: Map<K, A>) => K[] {
+export function keys<K>(O: T.Ord<K>): <A>(ta: ReadonlyMap<K, A>) => K[] {
   const _compare = toCompare(O);
   return (ta) => Array.from(ta.keys()).sort(_compare);
 }
 
-export function values<A>(O: T.Ord<A>): <K>(ta: Map<K, A>) => A[] {
+export function values<A>(O: T.Ord<A>): <K>(ta: ReadonlyMap<K, A>) => A[] {
   const _compare = toCompare(O);
   return (ta) => Array.from(ta.values()).sort(_compare);
 }
 
 export function collect<B>(
   O: T.Ord<B>,
-): <A, I>(fai: (b: B, a: A) => I) => (ta: Map<B, A>) => ReadonlyArray<I> {
+): <A, I>(
+  fai: (b: B, a: A) => I,
+) => (ta: ReadonlyMap<B, A>) => ReadonlyArray<I> {
   const _entries = entries(O);
   return (fai) =>
     flow(
@@ -156,7 +153,7 @@ export function collect<B>(
 
 export function deleteAt<B>(
   S: T.Setoid<B>,
-): (key: B) => <A>(map: Map<B, A>) => Map<B, A> {
+): (key: B) => <A>(map: ReadonlyMap<B, A>) => ReadonlyMap<B, A> {
   const _lookup = lookupWithKey(S);
   return (key) => (map) =>
     pipe(
@@ -176,7 +173,9 @@ export function insert<B>(
   S: T.Setoid<B>,
 ) {
   const _lookup = lookupWithKey(S);
-  return <A>(value: A) => (key: B) => (map: Map<B, A>): Map<B, A> =>
+  return <A>(value: A) =>
+  (key: B) =>
+  (map: ReadonlyMap<B, A>): ReadonlyMap<B, A> =>
     pipe(
       _lookup(key)(map),
       O.fold(
@@ -206,7 +205,9 @@ export function insertAt<B>(
 
 export function modify<B>(
   S: T.Setoid<B>,
-): <A>(modifyFn: (a: A) => A) => (key: B) => (ta: Map<B, A>) => Map<B, A> {
+): <A>(
+  modifyFn: (a: A) => A,
+) => (key: B) => (ta: ReadonlyMap<B, A>) => ReadonlyMap<B, A> {
   const _lookup = lookupWithKey(S);
   return (modifyFn) => (key) => (map) =>
     pipe(
@@ -224,25 +225,29 @@ export function modify<B>(
 
 export function modifyAt<B>(
   S: T.Setoid<B>,
-): (key: B) => <A>(modifyFn: (value: A) => A) => (map: Map<B, A>) => Map<B, A> {
+): (
+  key: B,
+) => <A>(
+  modifyFn: (value: A) => A,
+) => (map: ReadonlyMap<B, A>) => ReadonlyMap<B, A> {
   return (key) => (modifyFn) => modify(S)(modifyFn)(key);
 }
 
 export function update<B>(
   S: T.Setoid<B>,
-): <A>(value: A) => (key: B) => (map: Map<B, A>) => Map<B, A> {
+): <A>(value: A) => (key: B) => (map: ReadonlyMap<B, A>) => ReadonlyMap<B, A> {
   return (value) => (key) => modify(S)(() => value)(key);
 }
 
 export function updateAt<B>(
   S: T.Setoid<B>,
-): (key: B) => <A>(value: A) => (map: Map<B, A>) => Map<B, A> {
+): (key: B) => <A>(value: A) => (map: ReadonlyMap<B, A>) => ReadonlyMap<B, A> {
   return (key) => (value) => modify(S)(() => value)(key);
 }
 
 export function pop<B>(
   S: T.Setoid<B>,
-): (b: B) => <A>(ta: Map<B, A>) => Option<[A, Map<B, A>]> {
+): (b: B) => <A>(ta: ReadonlyMap<B, A>) => Option<[A, ReadonlyMap<B, A>]> {
   const _lookup = lookup(S);
   const _deleteAt = deleteAt(S);
   return (b) => {
@@ -259,7 +264,7 @@ export function pop<B>(
 export function isSubmap<K, A>(
   SK: T.Setoid<K>,
   SA: T.Setoid<A>,
-): (sub: Map<K, A>) => (sup: Map<K, A>) => boolean {
+): (sub: ReadonlyMap<K, A>) => (sup: ReadonlyMap<K, A>) => boolean {
   const _lookupWithKey = lookupWithKey(SK);
   return (sub) => {
     return (sup) => {
@@ -284,13 +289,13 @@ export const Bifunctor: T.Bifunctor<URI> = { bimap, mapLeft };
 export function getShow<K, A>(
   SK: T.Show<K>,
   SA: T.Show<A>,
-): T.Show<Map<K, A>> {
+): T.Show<ReadonlyMap<K, A>> {
   return ({
     show: (ta) => {
       const elements = Array.from(ta).map(([k, a]) =>
         `[${SK.show(k)}, ${SA.show(a)}]`
       ).join(", ");
-      return `new Map([${elements}])`;
+      return `new ReadonlyMap([${elements}])`;
     },
   });
 }
@@ -298,7 +303,7 @@ export function getShow<K, A>(
 export function getSetoid<K, A>(
   SK: T.Setoid<K>,
   SA: T.Setoid<A>,
-): T.Setoid<Map<K, A>> {
+): T.Setoid<ReadonlyMap<K, A>> {
   const submap = isSubmap(SK, SA);
   return fromEquals((x) => (y) => submap(x)(y) && submap(y)(x));
 }
@@ -306,7 +311,7 @@ export function getSetoid<K, A>(
 export function getMonoid<K, A>(
   SK: T.Setoid<K>,
   SA: T.Semigroup<A>,
-): T.Monoid<Map<K, A>> {
+): T.Monoid<ReadonlyMap<K, A>> {
   const lookupKey = lookupWithKey(SK);
   return {
     concat: (a) => (b) => {

--- a/monad.ts
+++ b/monad.ts
@@ -1,5 +1,4 @@
-// deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Applicative } from "./applicative.ts";
 import type { Chain } from "./chain.ts";
 
@@ -12,31 +11,27 @@ import { identity, pipe } from "./fns.ts";
  * Here we extend Monad with a join function. Other names for join
  * are flatten or flat.
  */
-export interface Monad<URI extends URIS, _ extends any[] = any[]>
-  extends Applicative<URI, _>, Chain<URI, _> {
-  readonly join: <A, B extends _[0], C extends _[1], D extends _[2]>(
-    tta: Kind<URI, [Kind<URI, [A, B, C, D]>, B, C, D]>,
-  ) => Kind<URI, [A, B, C, D]>;
+export interface Monad<U extends Kind> extends Applicative<U>, Chain<U> {
+  readonly join: <A, B, C, D>(
+    tta: $<U, [$<U, [A, B, C, D]>, B, C, D]>,
+  ) => $<U, [A, B, C, D]>;
 }
 
 /**
  * MonadThrow
  * https://github.com/gcanti/fp-ts/blob/master/src/MonadThrow.ts
  */
-export interface MonadThrow<URI extends URIS, _ extends any[] = any[]>
-  extends Monad<URI, _> {
-  readonly throwError: <A, B extends _[0], C extends _[1], D extends _[2]>(
-    b: B,
-  ) => Kind<URI, [A, B, C, D]>;
+export interface MonadThrow<U extends Kind> extends Monad<U> {
+  readonly throwError: <A, B, C, D>(b: B) => $<U, [A, B, C, D]>;
 }
 
 /**
  * Derive Monad module from of and chain
  */
-export function createMonad<URI extends URIS, _ extends any[] = any[]>(
-  { of, chain }: Pick<Monad<URI, _>, "of" | "chain">,
-): Monad<URI, _> {
-  const Monad: Monad<URI, _> = {
+export function createMonad<U extends Kind>(
+  { of, chain }: Pick<Monad<U>, "of" | "chain">,
+): Monad<U> {
+  const Monad: Monad<U> = {
     of,
     ap: (tfai) => (ta) => pipe(tfai, chain((fab) => pipe(ta, Monad.map(fab)))),
     map: (fai) => (ta) => pipe(ta, chain((a) => of(fai(a)))),
@@ -48,13 +43,13 @@ export function createMonad<URI extends URIS, _ extends any[] = any[]>(
 
 // Following is an initial implementation of Do notation that is incomplete
 
-// export type Do<URI extends URIS> = <B = never, C = never, D = never>() => Kind<
-//   URI,
+// export type Do<U extends Kind> = <B = never, C = never, D = never>() => $<
+//   U,
 //   // deno-lint-ignore ban-types
 //   [{}, B, C, D]
 // >;
 
-// export type Bind<URI extends URIS> = <
+// export type Bind<U extends Kind> = <
 //   N extends string,
 //   A,
 //   I,
@@ -63,9 +58,9 @@ export function createMonad<URI extends URIS, _ extends any[] = any[]>(
 //   D = never,
 // >(
 //   name: Exclude<N, keyof A>,
-//   fati: (a: A) => Kind<URI, [I, B, C, D]>,
-// ) => (ta: Kind<URI, [A, B, C, D]>) => Kind<
-//   URI,
+//   fati: (a: A) => $<U, [I, B, C, D]>,
+// ) => (ta: $<U, [A, B, C, D]>) => $<
+//   U,
 //   [
 //     { readonly [K in keyof A | N]: K extends keyof A ? A[K] : I },
 //     B,
@@ -74,17 +69,17 @@ export function createMonad<URI extends URIS, _ extends any[] = any[]>(
 //   ]
 // >;
 
-// export type BindTo<URI extends URIS> = <N extends string>(
+// export type BindTo<U extends Kind> = <N extends string>(
 //   name: N,
 // ) => <A, B = never, C = never, D = never>(
-//   ta: Kind<URI, [A, B, C, D]>,
-// ) => Kind<URI, [{ [K in N]: A }, B, C, D]>;
+//   ta: $<U, [A, B, C, D]>,
+// ) => $<U, [{ [K in N]: A }, B, C, D]>;
 
-// function makeDo<URI extends URIS>(M: T.Monad<URI>): Do<URI> {
+// function makeDo<U extends Kind>(M: T.Monad<U>): Do<U> {
 //   return () => M.of({});
 // }
 
-// function makeBind<URI extends URIS>(M: T.Monad<URI>): Bind<URI> {
+// function makeBind<U extends Kind>(M: T.Monad<U>): Bind<U> {
 //   return (name, fati) =>
 //     M.chain((a) => {
 //       const ti = fati(a);
@@ -93,13 +88,13 @@ export function createMonad<URI extends URIS, _ extends any[] = any[]>(
 //     });
 // }
 
-// function makeBindTo<URI extends URIS>(M: T.Monad<URI>): BindTo<URI> {
+// function makeBindTo<U extends Kind>(M: T.Monad<U>): BindTo<U> {
 //   // deno-lint-ignore no-explicit-any
 //   return (name) => M.map((a) => ({ [name]: a })) as any;
 // }
 
-// export function createDo<URI extends URIS>(
-//   M: T.Monad<URI>,
+// export function createDo<U extends Kind>(
+//   M: T.Monad<U>,
 // ) {
 //   return {
 //     Do: makeDo(M),

--- a/nilable.ts
+++ b/nilable.ts
@@ -6,7 +6,7 @@
  * Nilable is a type like Maybe/Option that uses undefined/null in lieu of tagged unions.
  * *****************************************************************************/
 
-import type * as __ from "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Predicate } from "./predicate.ts";
 
@@ -17,15 +17,8 @@ export type Nil = undefined | null;
 
 export type Nilable<A> = Nil | A;
 
-export const URI = "Nilable";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Nilable<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Nilable<this[0]>;
 }
 
 export const nil: Nil = undefined;

--- a/option.ts
+++ b/option.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Predicate } from "./predicate.ts";
 
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
@@ -22,15 +22,8 @@ export type Some<V> = { tag: "Some"; value: V };
  */
 export type Option<A> = Some<A> | None;
 
-export const URI = "Option";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Option<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Option<this[0]>;
 }
 
 /**
@@ -241,10 +234,10 @@ export function reduce<A, O>(
   return (ta) => isSome(ta) ? foao(o, ta.value) : o;
 }
 
-export function traverse<VRI extends URIS>(A: T.Applicative<VRI>) {
+export function traverse<V extends Kind>(A: T.Applicative<V>) {
   return <A, I, J, K, L>(
-    favi: (a: A) => Kind<VRI, [I, J, K, L]>,
-  ): (ta: Option<A>) => Kind<VRI, [Option<I>, J, K, L]> =>
+    favi: (a: A) => $<V, [I, J, K, L]>,
+  ): (ta: Option<A>) => $<V, [Option<I>, J, K, L]> =>
     fold(
       () => A.of(constNone()),
       (a) => pipe(favi(a), A.map((i) => some(i))),

--- a/optional.ts
+++ b/optional.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Either } from "./either.ts";
 import type { Option } from "./option.ts";
 import type { Predicate } from "./predicate.ts";
@@ -74,7 +74,9 @@ export function indexRecord<A>(): Index<
   });
 }
 
-export function indexMap<A, B>(setoid: T.Setoid<B>): Index<Map<B, A>, B, A> {
+export function indexMap<A, B>(
+  setoid: T.Setoid<B>,
+): Index<ReadonlyMap<B, A>, B, A> {
   const lookup = M.lookup(setoid);
   const updateAt = M.updateAt(setoid);
   return ({
@@ -253,10 +255,10 @@ export function map<A, B>(
     );
 }
 
-export function traverse<URI extends URIS>(
-  T: T.Traversable<URI>,
+export function traverse<U extends Kind>(
+  T: T.Traversable<U>,
 ): <S, A, B = never, C = never, D = never>(
-  sa: Optional<S, Kind<URI, [A, B, C, D]>>,
+  sa: Optional<S, $<U, [A, B, C, D]>>,
 ) => Traversal<S, A> {
   const _traversal = toTraversal(T);
   return (sa) => composeTraversal(sa, _traversal());

--- a/plus.ts
+++ b/plus.ts
@@ -1,15 +1,10 @@
-// deno-lint-ignore-file no-explicit-any
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Alt } from "./alt.ts";
 
 /**
  * Plus
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#plus
  */
-export interface Plus<URI extends URIS, _ extends any[] = any[]>
-  extends Alt<URI, _> {
-  readonly zero: <A, B extends _[0], C extends _[1], D extends _[2]>() => Kind<
-    URI,
-    [A, B, C, D]
-  >;
-}
+export type Plus<U extends Kind> = Alt<U> & {
+  readonly zero: <A, B, C, D>() => $<U, [A, B, C, D]>;
+};

--- a/predicate.ts
+++ b/predicate.ts
@@ -1,4 +1,4 @@
-import * as __ from "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import { flow } from "./fns.ts";
@@ -36,15 +36,8 @@ import { flow } from "./fns.ts";
  */
 export type Predicate<A> = (a: A) => boolean;
 
-export const URI = "Predicate";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Predicate<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Predicate<this[0]>;
 }
 
 // ---

--- a/prism.ts
+++ b/prism.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Predicate } from "./predicate.ts";
 import type { Refinement } from "./refinement.ts";
 
@@ -196,10 +196,10 @@ export function filter<A>(
     );
 }
 
-export function traverse<URI extends URIS>(
-  T: T.Traversable<URI>,
-): <S, A, B = never, C = never, D = never>(
-  sa: Prism<S, Kind<URI, [A, B, C, D]>>,
+export function traverse<U extends Kind>(
+  T: T.Traversable<U>,
+): <S, A, B, C, D>(
+  sa: Prism<S, $<U, [A, B, C, D]>>,
 ) => Traversal<S, A> {
   const _traversal = toTraversal(T);
   return (sa) => composeTraversal(sa, _traversal());

--- a/profunctor.ts
+++ b/profunctor.ts
@@ -1,14 +1,12 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 /**
  * Profunctor
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#profunctor
  */
-export interface Profunctor<URI extends URIS> {
+export interface Profunctor<U extends Kind> {
   readonly promap: <A, B, I, X>(
     fai: (a: A) => I,
     fbj: (b: B) => X,
-  ) => <C, D>(
-    tib: Kind<URI, [I, B, C, D]>,
-  ) => Kind<URI, [A, X, C, D]>;
+  ) => <C, D>(tib: $<U, [I, B, C, D]>) => $<U, [A, X, C, D]>;
 }

--- a/reader.ts
+++ b/reader.ts
@@ -1,65 +1,58 @@
-import "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import { flow, pipe } from "./fns.ts";
 
-export type Reader<B extends unknown[], A> = (...b: B) => A;
+export type Reader<B, A> = (b: B) => A;
 
-export const URI = "Reader";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Reader<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Reader<this[1], this[0]>;
 }
 
-export function ask<A extends unknown[]>(): Reader<A, A> {
-  return (...as) => as;
+export function ask<A>(): Reader<A, A> {
+  return (a) => a;
 }
 
-export function asks<A extends unknown[], I>(
-  fai: (...a: A) => I,
+export function asks<A, I>(
+  fai: (a: A) => I,
 ): Reader<A, I> {
   return fai;
 }
 
-export function of<A, B extends unknown[] = []>(a: A): Reader<B, A> {
+export function of<A, B = []>(a: A): Reader<B, A> {
   return () => a;
 }
 
 export function map<A, I>(
   fai: (a: A) => I,
-): <B extends unknown[]>(ta: Reader<B, A>) => Reader<B, I> {
+): <B>(ta: Reader<B, A>) => Reader<B, I> {
   return (ta) => flow(ta, fai);
 }
 
-export function ap<A, I, B extends unknown[]>(
+export function ap<A, I, B>(
   tfai: Reader<B, (a: A) => I>,
 ): (ta: Reader<B, A>) => Reader<B, I> {
   return (ta) => (...b) => pipe(ta(...b), tfai(...b));
 }
 
-export function chain<A, I, B extends unknown[]>(
+export function chain<A, I, B>(
   fati: (a: A) => Reader<B, I>,
 ): (ta: Reader<B, A>) => Reader<B, I> {
   return (ta) => (...b) => fati(ta(...b))(...b);
 }
 
-export function join<A, B extends unknown[]>(
+export function join<A, B>(
   tta: Reader<B, Reader<B, A>>,
 ): Reader<B, A> {
   return (...b) => tta(...b)(...b);
 }
 
-export const Functor: T.Functor<URI, [unknown[]]> = { map };
+export const Functor: T.Functor<URI> = { map };
 
-export const Apply: T.Apply<URI, [unknown[]]> = { ap, map };
+export const Apply: T.Apply<URI> = { ap, map };
 
-export const Applicative: T.Applicative<URI, [unknown[]]> = { of, ap, map };
+export const Applicative: T.Applicative<URI> = { of, ap, map };
 
-export const Chain: T.Chain<URI, [unknown[]]> = { ap, map, chain };
+export const Chain: T.Chain<URI> = { ap, map, chain };
 
-export const Monad: T.Monad<URI, [unknown[]]> = { of, ap, map, join, chain };
+export const Monad: T.Monad<URI> = { of, ap, map, join, chain };

--- a/reader_either.ts
+++ b/reader_either.ts
@@ -5,68 +5,65 @@ import * as E from "./either.ts";
 import * as R from "./reader.ts";
 import { flow, handleThrow, identity, pipe } from "./fns.ts";
 
-export type ReaderEither<S extends unknown[], L, R> = R.Reader<
+export type ReaderEither<S, L, R> = R.Reader<
   S,
   E.Either<L, R>
 >;
 
-export const URI = "ReaderEither";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: ReaderEither<_[2], _[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: ReaderEither<this[2], this[1], this[0]>;
 }
 
-export function ask<A extends unknown[], B = never>(): ReaderEither<A, B, A> {
-  return (...a) => E.right(a);
+export interface RightURI<B> extends Kind {
+  readonly type: ReaderEither<this[1], B, this[0]>;
 }
 
-export function asks<A, B = never, C extends unknown[] = []>(
-  fca: (...c: C) => A,
+export function ask<A, B = never>(): ReaderEither<A, B, A> {
+  return E.right;
+}
+
+export function asks<A, B = never, C = never>(
+  fca: (c: C) => A,
 ): ReaderEither<C, B, A> {
   return flow(fca, E.right);
 }
 
-export function left<A = never, B = never, C extends unknown[] = []>(
+export function left<A = never, B = never, C = never>(
   left: B,
 ): ReaderEither<C, B, A> {
   return R.of(E.left(left));
 }
 
-export function right<A, B = never, C extends unknown[] = []>(
+export function right<A, B = never, C = never>(
   right: A,
 ): ReaderEither<C, B, A> {
   return R.of(E.right(right));
 }
 
-export function tryCatch<A, B, C extends unknown[]>(
-  fca: (...c: C) => A,
+export function tryCatch<A, B, C>(
+  fca: (c: C) => A,
   onThrow: (e: unknown, c: C) => B,
 ): ReaderEither<C, B, A> {
   return handleThrow(
     fca,
     (a) => E.right(a),
-    (e, c) => E.left(onThrow(e, c)),
+    (e, [c]) => E.left(onThrow(e, c)),
   );
 }
 
-export function fromEither<A, B, C extends unknown[] = []>(
+export function fromEither<A, B, C = never>(
   ta: E.Either<B, A>,
 ): ReaderEither<C, B, A> {
   return R.of(ta);
 }
 
-export function of<A, B = never, C extends unknown[] = []>(
+export function of<A, B = never, C = never>(
   a: A,
 ): ReaderEither<C, B, A> {
   return right(a);
 }
 
-export function throwError<A = never, B = never, C extends unknown[] = []>(
+export function throwError<A = never, B = never, C = never>(
   b: B,
 ): ReaderEither<C, B, A> {
   return left(b);
@@ -75,7 +72,7 @@ export function throwError<A = never, B = never, C extends unknown[] = []>(
 export function bimap<A, I, B, J>(
   fbj: (b: B) => J,
   fai: (a: A) => I,
-): <C extends unknown[] = []>(
+): <C = never>(
   ta: ReaderEither<C, B, A>,
 ) => ReaderEither<C, J, I> {
   return (tab) => flow(tab, E.bimap(fbj, fai));
@@ -83,7 +80,7 @@ export function bimap<A, I, B, J>(
 
 export function map<A, I>(
   fai: (a: A) => I,
-): <B = never, C extends unknown[] = []>(
+): <B = never, C = never>(
   ta: ReaderEither<C, B, A>,
 ) => ReaderEither<C, B, I> {
   return bimap(identity, fai);
@@ -91,68 +88,65 @@ export function map<A, I>(
 
 export function mapLeft<B, J>(
   fbj: (b: B) => J,
-): <A = never, C extends unknown[] = []>(
+): <A = never, C = never>(
   ta: ReaderEither<C, B, A>,
 ) => ReaderEither<C, J, A> {
   return bimap(fbj, identity);
 }
 
-export function ap<A, I, B, C extends unknown[] = []>(
+// TODO: Decide if this should be lazy over tfai
+export function ap<A, I, B, C = never>(
   tfai: ReaderEither<C, B, (a: A) => I>,
 ): (ta: ReaderEither<C, B, A>) => ReaderEither<C, B, I> {
-  return (ta) => (...c) =>
-    pipe(tfai(...c), E.chain((fai) => pipe(ta(...c), E.map(fai))));
+  return (ta) => (c) => pipe(ta(c), E.ap(tfai(c)));
 }
 
-export function chain<A, C extends unknown[], I, J>(
+export function chain<A, C, I, J>(
   fati: (a: A) => ReaderEither<C, J, I>,
 ): <B>(ta: ReaderEither<C, B, A>) => ReaderEither<C, B | J, I> {
-  return (ta) => (...c) => {
-    const e = ta(...c);
-    return E.isLeft(e) ? e : fati(e.right)(...c);
+  return (ta) => (c) => {
+    const e = ta(c);
+    return E.isLeft(e) ? e : fati(e.right)(c);
   };
 }
 
-export function join<A, B, C extends unknown[]>(
+export function join<A, B, C>(
   tta: ReaderEither<C, B, ReaderEither<C, B, A>>,
 ): ReaderEither<C, B, A> {
   return pipe(tta, chain(identity));
 }
 
-export function alt<A, B, C extends unknown[]>(
+export function alt<A, B, C>(
   tb: ReaderEither<C, B, A>,
 ): (ta: ReaderEither<C, B, A>) => ReaderEither<C, B, A> {
-  return (ta) => (...c) => {
-    const e = ta(...c);
-    return E.isLeft(e) ? tb(...c) : e;
+  return (ta) => (c) => {
+    const e = ta(c);
+    return E.isLeft(e) ? tb(c) : e;
   };
 }
 
-export function chainLeft<A, B, C extends unknown[], J>(
+export function chainLeft<A, B, C, J>(
   fbtj: (b: B) => ReaderEither<C, J, A>,
 ): (ta: ReaderEither<C, B, A>) => ReaderEither<C, J, A> {
   return (ta) => pipe(ta, R.chain(E.fold(fbtj, right)));
 }
 
-export function compose<A extends unknown[], I, J>(
+export function compose<A, I, J>(
   right: ReaderEither<A, J, I>,
-): <B, C extends unknown[]>(
+): <B, C>(
   left: ReaderEither<C, B, A>,
 ) => ReaderEither<C, B | J, I> {
-  return (left) => flow(left, E.chain((a) => right(...a)));
+  return (left) => flow(left, E.chain((a) => right(a)));
 }
 
 export function getRightMonad<B>(
   { concat }: T.Semigroup<B>,
-): T.MonadThrow<URI, [B, unknown[]]> {
+): T.Monad<RightURI<B>> {
   return ({
     of,
-    ap: (tfai) =>
-    // deno-lint-ignore no-explicit-any
-    (ta): ReaderEither<any, any, any> =>
-    (...c) => {
-      const efai = tfai(...c);
-      const ea = ta(...c);
+    ap: (tfai) => (ta) => (c) => {
+      const efai = tfai(c);
+      const ea = ta(c);
       return E.isLeft(efai)
         ? (E.isLeft(ea) ? E.left(concat(efai.left)(ea.left)) : efai)
         : (E.isLeft(ea) ? ea : E.right(efai.right(ea.right)));
@@ -160,28 +154,22 @@ export function getRightMonad<B>(
     map,
     join,
     chain,
-    throwError,
   });
 }
 
-// deno-lint-ignore no-explicit-any
-export const Functor: T.Functor<URI, [any, unknown[]]> = { map };
+export const Functor: T.Functor<URI> = { map };
 
-// deno-lint-ignore no-explicit-any
-export const Apply: T.Apply<URI, [any, unknown[]]> = { ap, map };
+export const Apply: T.Apply<URI> = { ap, map };
 
-// deno-lint-ignore no-explicit-any
-export const Applicative: T.Applicative<URI, [any, unknown[]]> = {
+export const Applicative: T.Applicative<URI> = {
   of,
   ap,
   map,
 };
 
-// deno-lint-ignore no-explicit-any
-export const Chain: T.Chain<URI, [any, unknown[]]> = { ap, map, chain };
+export const Chain: T.Chain<URI> = { ap, map, chain };
 
-// deno-lint-ignore no-explicit-any
-export const Monad: T.Monad<URI, [any, unknown[]]> = {
+export const Monad: T.Monad<URI> = {
   of,
   ap,
   map,
@@ -189,11 +177,9 @@ export const Monad: T.Monad<URI, [any, unknown[]]> = {
   chain,
 };
 
-// deno-lint-ignore no-explicit-any
-export const Bifunctor: T.Bifunctor<URI, [any, unknown[]]> = { bimap, mapLeft };
+export const Bifunctor: T.Bifunctor<URI> = { bimap, mapLeft };
 
-// deno-lint-ignore no-explicit-any
-export const MonadThrow: T.MonadThrow<URI, [any, unknown[]]> = {
+export const MonadThrow: T.MonadThrow<URI> = {
   of,
   ap,
   map,
@@ -202,5 +188,4 @@ export const MonadThrow: T.MonadThrow<URI, [any, unknown[]]> = {
   throwError,
 };
 
-// deno-lint-ignore no-explicit-any
-export const Alt: T.Alt<URI, [any, unknown[]]> = { alt, map };
+export const Alt: T.Alt<URI> = { alt, map };

--- a/schemable.ts
+++ b/schemable.ts
@@ -1,38 +1,38 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 
 import { memoize } from "./fns.ts";
 
 export type Literal = string | number | boolean | null | undefined;
 
-export type UnknownSchemable<URI extends URIS> = {
-  readonly unknown: <B = never, C = never, D = never>() => Kind<
-    URI,
+export type UnknownSchemable<U extends Kind> = {
+  readonly unknown: <B = never, C = never, D = never>() => $<
+    U,
     [unknown, B, C, D]
   >;
 };
 
-export type StringSchemable<URI extends URIS> = {
-  readonly string: <B = never, C = never, D = never>() => Kind<
-    URI,
+export type StringSchemable<U extends Kind> = {
+  readonly string: <B = never, C = never, D = never>() => $<
+    U,
     [string, B, C, D]
   >;
 };
 
-export type NumberSchemable<URI extends URIS> = {
-  readonly number: <B = never, C = never, D = never>() => Kind<
-    URI,
+export type NumberSchemable<U extends Kind> = {
+  readonly number: <B = never, C = never, D = never>() => $<
+    U,
     [number, B, C, D]
   >;
 };
 
-export type BooleanSchemable<URI extends URIS> = {
-  readonly boolean: <B = never, C = never, D = never>() => Kind<
-    URI,
+export type BooleanSchemable<U extends Kind> = {
+  readonly boolean: <B = never, C = never, D = never>() => $<
+    U,
     [boolean, B, C, D]
   >;
 };
 
-export type LiteralSchemable<URI extends URIS> = {
+export type LiteralSchemable<U extends Kind> = {
   readonly literal: <
     A extends [Literal, ...Literal[]],
     B = never,
@@ -40,98 +40,98 @@ export type LiteralSchemable<URI extends URIS> = {
     D = never,
   >(
     ...s: A
-  ) => Kind<URI, [A[number], B, C, D]>;
+  ) => $<U, [A[number], B, C, D]>;
 };
 
-export type NullableSchemable<URI extends URIS> = {
+export type NullableSchemable<U extends Kind> = {
   readonly nullable: <A, B = never, C = never, D = never>(
-    or: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A | null, B, C, D]>;
+    or: $<U, [A, B, C, D]>,
+  ) => $<U, [A | null, B, C, D]>;
 };
 
-export type UndefinableSchemable<URI extends URIS> = {
+export type UndefinableSchemable<U extends Kind> = {
   readonly undefinable: <A, B = never, C = never, D = never>(
-    or: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A | undefined, B, C, D]>;
+    or: $<U, [A, B, C, D]>,
+  ) => $<U, [A | undefined, B, C, D]>;
 };
 
-export type RecordSchemable<URI extends URIS> = {
+export type RecordSchemable<U extends Kind> = {
   readonly record: <A, B = never, C = never, D = never>(
-    codomain: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [Record<string, A>, B, C, D]>;
+    codomain: $<U, [A, B, C, D]>,
+  ) => $<U, [Record<string, A>, B, C, D]>;
 };
 
-export type ArraySchemable<URI extends URIS> = {
+export type ArraySchemable<U extends Kind> = {
   readonly array: <A, B = never, C = never, D = never>(
-    item: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [ReadonlyArray<A>, B, C, D]>;
+    item: $<U, [A, B, C, D]>,
+  ) => $<U, [ReadonlyArray<A>, B, C, D]>;
 };
 
-export type TupleSchemable<URI extends URIS> = {
+export type TupleSchemable<U extends Kind> = {
   // deno-lint-ignore no-explicit-any
   readonly tuple: <A extends any[], B = never, C = never, D = never>(
-    ...items: { [K in keyof A]: Kind<URI, [A[K], B, C, D]> }
-  ) => Kind<URI, [{ [K in keyof A]: A[K] }, B, C, D]>;
+    ...items: { [K in keyof A]: $<U, [A[K], B, C, D]> }
+  ) => $<U, [{ [K in keyof A]: A[K] }, B, C, D]>;
 };
 
-export type StructSchemable<URI extends URIS> = {
+export type StructSchemable<U extends Kind> = {
   readonly struct: <A, B = never, C = never, D = never>(
-    items: { [K in keyof A]: Kind<URI, [A[K], B, C, D]> },
-  ) => Kind<URI, [{ [K in keyof A]: A[K] }, B, C, D]>;
+    items: { [K in keyof A]: $<U, [A[K], B, C, D]> },
+  ) => $<U, [{ [K in keyof A]: A[K] }, B, C, D]>;
 };
 
-export type PartialSchemable<URI extends URIS> = {
+export type PartialSchemable<U extends Kind> = {
   readonly partial: <A, B = never, C = never, D = never>(
-    items: { [K in keyof A]: Kind<URI, [A[K], B, C, D]> },
-  ) => Kind<URI, [{ [K in keyof A]?: A[K] | null }, B, C, D]>;
+    items: { [K in keyof A]: $<U, [A[K], B, C, D]> },
+  ) => $<U, [{ [K in keyof A]?: A[K] | null }, B, C, D]>;
 };
 
-export type IntersectSchemable<URI extends URIS> = {
+export type IntersectSchemable<U extends Kind> = {
   readonly intersect: <I, B = never, C = never, D = never>(
-    and: Kind<URI, [I, B, C, D]>,
+    and: $<U, [I, B, C, D]>,
   ) => <A>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A & I, B, C, D]>;
+    ta: $<U, [A, B, C, D]>,
+  ) => $<U, [A & I, B, C, D]>;
 };
 
-export type UnionSchemable<URI extends URIS> = {
+export type UnionSchemable<U extends Kind> = {
   readonly union: <I, B = never, C = never, D = never>(
-    or: Kind<URI, [I, B, C, D]>,
-  ) => <A>(ta: Kind<URI, [A, B, C, D]>) => Kind<URI, [A | I, B, C, D]>;
+    or: $<U, [I, B, C, D]>,
+  ) => <A>(ta: $<U, [A, B, C, D]>) => $<U, [A | I, B, C, D]>;
 };
 
-export type LazySchemable<URI extends URIS> = {
+export type LazySchemable<U extends Kind> = {
   readonly lazy: <A, B = never, C = never, D = never>(
     id: string,
-    f: () => Kind<URI, [A, B, C, D]>,
-  ) => Kind<URI, [A, B, C, D]>;
+    f: () => $<U, [A, B, C, D]>,
+  ) => $<U, [A, B, C, D]>;
 };
 
-export type Schemable<URI extends URIS> =
-  & UnknownSchemable<URI>
-  & StringSchemable<URI>
-  & NumberSchemable<URI>
-  & BooleanSchemable<URI>
-  & LiteralSchemable<URI>
-  & NullableSchemable<URI>
-  & UndefinableSchemable<URI>
-  & RecordSchemable<URI>
-  & ArraySchemable<URI>
-  & TupleSchemable<URI>
-  & StructSchemable<URI>
-  & PartialSchemable<URI>
-  & IntersectSchemable<URI>
-  & UnionSchemable<URI>
-  & LazySchemable<URI>;
+export type Schemable<U extends Kind> =
+  & UnknownSchemable<U>
+  & StringSchemable<U>
+  & NumberSchemable<U>
+  & BooleanSchemable<U>
+  & LiteralSchemable<U>
+  & NullableSchemable<U>
+  & UndefinableSchemable<U>
+  & RecordSchemable<U>
+  & ArraySchemable<U>
+  & TupleSchemable<U>
+  & StructSchemable<U>
+  & PartialSchemable<U>
+  & IntersectSchemable<U>
+  & UnionSchemable<U>
+  & LazySchemable<U>;
 
-export type Schema<A, B = never, C = never, D = never> = <URI extends URIS>(
-  s: Schemable<URI>,
-) => Kind<URI, [A, B, C, D]>;
+export type Schema<A, B = never, C = never, D = never> = <U extends Kind>(
+  s: Schemable<U>,
+) => $<U, [A, B, C, D]>;
 
 export type TypeOf<T> = T extends Schema<infer A> ? A : never;
 
 export function schema<A, B = never, C = never, D = never>(
-  f: (s: Schemable<URIS>) => Kind<URIS, [A, B, C, D]>,
+  f: (s: Schemable<Kind>) => $<Kind, [A, B, C, D]>,
 ): Schema<A, B, C, D> {
   // deno-lint-ignore no-explicit-any
   return memoize(f) as any;

--- a/semigroup.ts
+++ b/semigroup.ts
@@ -1,5 +1,3 @@
-// deno-lint-ignore-file no-explicit-any
-
 import type { Ord } from "./ord.ts";
 
 import { reduce } from "./array.ts";
@@ -90,11 +88,14 @@ export function getLastSemigroup<A = never>(): Semigroup<A> {
   return ({ concat: (_) => (y) => y });
 }
 
+// deno-lint-ignore no-explicit-any
 export function getTupleSemigroup<T extends ReadonlyArray<Semigroup<any>>>(
   ...semigroups: T
 ): Semigroup<{ [K in keyof T]: T[K] extends Semigroup<infer A> ? A : never }> {
+  type Return = { [K in keyof T]: T[K] extends Semigroup<infer A> ? A : never };
   return ({
-    concat: (x) => (y) => semigroups.map((s, i) => s.concat(x[i])(y[i])) as any,
+    concat: (x) => (y) =>
+      semigroups.map((s, i) => s.concat(x[i])(y[i])) as unknown as Return,
   });
 }
 
@@ -102,6 +103,7 @@ export function getDualSemigroup<A>(S: Semigroup<A>): Semigroup<A> {
   return ({ concat: (x) => (y) => S.concat(y)(x) });
 }
 
+// deno-lint-ignore no-explicit-any
 export function getStructSemigroup<O extends Readonly<Record<string, any>>>(
   semigroups: { [K in keyof O]: Semigroup<O[K]> },
 ): Semigroup<O> {

--- a/separated.ts
+++ b/separated.ts
@@ -1,5 +1,5 @@
-import type * as __ from "./kind.ts";
-import * as T from "./types.ts";
+import type { Kind } from "./kind.ts";
+import type * as T from "./types.ts";
 
 /**
  * Separated
@@ -8,15 +8,8 @@ import * as T from "./types.ts";
  */
 export type Separated<B, A> = { readonly left: B; readonly right: A };
 
-export const URI = "Separated";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Separated<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Separated<this[1], this[0]>;
 }
 
 export function separated<A, B>(left: B, right: A): Separated<B, A> {

--- a/setoid.ts
+++ b/setoid.ts
@@ -1,5 +1,3 @@
-// deno-lint-ignore-file no-explicit-any
-
 /**
  * Setoid
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#setoid
@@ -12,7 +10,7 @@ export function fromEquals<A>(equals: (x: A) => (y: A) => boolean): Setoid<A> {
   return ({ equals: (x) => (y) => x === y || equals(x)(y) });
 }
 
-export function getStructSetoid<O extends Readonly<Record<string, any>>>(
+export function getStructSetoid<O extends Readonly<Record<string, unknown>>>(
   eqs: { [K in keyof O]: Setoid<O[K]> },
 ): Setoid<O> {
   return fromEquals((x) => (y) => {
@@ -25,13 +23,15 @@ export function getStructSetoid<O extends Readonly<Record<string, any>>>(
   });
 }
 
-export function getTupleSetoid<T extends ReadonlyArray<Setoid<any>>>(
+export function getTupleSetoid<T extends ReadonlyArray<Setoid<unknown>>>(
   ...eqs: T
 ): Setoid<{ [K in keyof T]: T[K] extends Setoid<infer A> ? A : never }> {
   return fromEquals((x) => (y) => eqs.every((E, i) => E.equals(x[i])(y[i])));
 }
 
-export function getValueOfSetoid<A extends { valueOf: () => any }>(): Setoid<
+export function getValueOfSetoid<
+  A extends { valueOf: () => unknown },
+>(): Setoid<
   A
 > {
   return {

--- a/state.ts
+++ b/state.ts
@@ -7,15 +7,8 @@ import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 
 export type State<S, A> = (s: S) => [A, S];
 
-export const URI = "State";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: State<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: State<this[1], this[0]>;
 }
 
 export function get<S>(): State<S, S> {

--- a/task.ts
+++ b/task.ts
@@ -1,19 +1,12 @@
-import "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import { handleThrow, resolve, wait } from "./fns.ts";
 
 export type Task<A> = () => Promise<A>;
 
-export const URI = "Task";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Task<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Task<this[0]>;
 }
 
 export function of<A>(a: A): Task<A> {

--- a/task_either.ts
+++ b/task_either.ts
@@ -1,4 +1,4 @@
-import "./kind.ts";
+import type { Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 import type { Task } from "./task.ts";
 import type { Either } from "./either.ts";
@@ -30,24 +30,8 @@ import { handleThrow, identity, pipe, resolve } from "./fns.ts";
  */
 export type TaskEither<L, R> = Task<Either<L, R>>;
 
-/**
- * URI constant for the TaskEither ADT
- */
-export const URI = "TaskEither";
-
-/**
- * URI constant type for the TaskEither ADT
- */
-export type URI = typeof URI;
-
-/**
- * Kind declaration for TaskEither
- */
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: TaskEither<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: TaskEither<this[1], this[0]>;
 }
 
 /**

--- a/testing/assert.ts
+++ b/testing/assert.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.77.0/testing/asserts.ts";
 
 import type * as T from "../types.ts";
 import type { Predicate } from "../predicate.ts";
-import type { Kind, URIS } from "../kind.ts";
+import type { $, Kind } from "../kind.ts";
 
 import { apply, flow, pipe } from "../fns.ts";
 
@@ -11,7 +11,7 @@ import { apply, flow, pipe } from "../fns.ts";
  * *****************************************************************************/
 
 export type MonadTest<
-  URI extends URIS,
+  URI extends Kind,
   A,
   B = never,
   C = never,
@@ -20,13 +20,13 @@ export type MonadTest<
   J = never,
 > = {
   a: A;
-  ta: Kind<URI, [A, B, C, D]>;
+  ta: $<URI, [A, B, C, D]>;
   fai: (a: A) => I;
   fij: (i: I) => J;
-  tfai: Kind<URI, [(a: A) => I, B, C, D]>;
-  tfij: Kind<URI, [(i: I) => J, B, C, D]>;
-  fati: (a: A) => Kind<URI, [I, B, C, D]>;
-  fitj: (i: I) => Kind<URI, [J, B, C, D]>;
+  tfai: $<URI, [(a: A) => I, B, C, D]>;
+  tfij: $<URI, [(i: I) => J, B, C, D]>;
+  fati: (a: A) => $<URI, [I, B, C, D]>;
+  fitj: (i: I) => $<URI, [J, B, C, D]>;
 };
 
 /** *****************************************************************************
@@ -38,10 +38,10 @@ export const add = (n: number) => n + 1;
 export const multiply = (n: number) => n * n;
 
 export const wrapAdd =
-  <URI extends URIS>(A: T.Applicative<URI>) => (n: number) => A.of(add(n));
+  <URI extends Kind>(A: T.Applicative<URI>) => (n: number) => A.of(add(n));
 
 export const wrapMultiply =
-  <URI extends URIS>(A: T.Applicative<URI>) => (n: number) => A.of(multiply(n));
+  <URI extends Kind>(A: T.Applicative<URI>) => (n: number) => A.of(multiply(n));
 
 /** *****************************************************************************
  * Assert: Setoid
@@ -171,7 +171,7 @@ export const assertMonoid = <T>(
  * *****************************************************************************/
 
 export const assertFilterable = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -179,8 +179,8 @@ export const assertFilterable = <
 >(
   F: T.Filterable<URI>,
   { a, b, f, g }: {
-    a: Kind<URI, [A, B, C, D]>;
-    b: Kind<URI, [A, B, C, D]>;
+    a: $<URI, [A, B, C, D]>;
+    b: $<URI, [A, B, C, D]>;
     f: Predicate<A>;
     g: Predicate<A>;
   },
@@ -209,7 +209,7 @@ export const assertFilterable = <
  * *****************************************************************************/
 
 export const assertFunctor = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -219,7 +219,7 @@ export const assertFunctor = <
 >(
   F: T.Functor<URI>,
   { ta, fai, fij }: {
-    ta: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
   },
@@ -242,7 +242,7 @@ export const assertFunctor = <
  * *****************************************************************************/
 
 export const assertBifunctor = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -254,7 +254,7 @@ export const assertBifunctor = <
 >(
   B: T.Bifunctor<URI>,
   { tab, fai, fij, fbx, fxy }: {
-    tab: Kind<URI, [A, B, C, D]>;
+    tab: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
     fbx: (b: B) => X;
@@ -285,7 +285,7 @@ export const assertBifunctor = <
  * *****************************************************************************/
 
 // export const assertContravariant = <
-//   URI extends URIS,
+//   URI extends Kind,
 //   A = never,
 //   B = never,
 //   C = never,
@@ -295,8 +295,8 @@ export const assertBifunctor = <
 // >(
 //   C: T.Contravariant<URI>,
 //   { ti, tj, fai, fij }: {
-//     ti: Kind<URI, [I, B, C, D]>;
-//     tj: Kind<URI, [J, B, C, D]>;
+//     ti: $<URI, [I, B, C, D]>;
+//     tj: $<URI, [J, B, C, D]>;
 //     fai: (a: A) => I;
 //     fij: (i: I) => J;
 //   },
@@ -320,7 +320,7 @@ export const assertBifunctor = <
  * *****************************************************************************/
 
 // export const assertProfunctor = <
-//   URI extends URIS,
+//   URI extends Kind,
 //   A = never,
 //   B = never,
 //   C = never,
@@ -332,7 +332,7 @@ export const assertBifunctor = <
 // >(
 //   P: T.Profunctor<URI>,
 //   { tay, fai, fij, fbx, fxy }: {
-//     tay: Kind<URI, [J, B, C, D]>;
+//     tay: $<URI, [J, B, C, D]>;
 //     fai: (a: A) => I;
 //     fij: (i: I) => J;
 //     fbx: (b: B) => X;
@@ -364,7 +364,7 @@ export const assertBifunctor = <
  * *****************************************************************************/
 
 export const assertApply = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -374,11 +374,11 @@ export const assertApply = <
 >(
   A: T.Apply<URI>,
   { ta, fai, fij, tfai, tfij }: {
-    ta: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
-    tfai: Kind<URI, [(a: A) => I, B, C, D]>;
-    tfij: Kind<URI, [(i: I) => J, B, C, D]>;
+    tfai: $<URI, [(a: A) => I, B, C, D]>;
+    tfij: $<URI, [(i: I) => J, B, C, D]>;
   },
 ): void => {
   // Composition: A.ap(A.ap(A.map(f => g => x => f(g(x)), a), u), v) ≡ A.ap(a, A.ap(u, v))
@@ -409,7 +409,7 @@ export const assertApply = <
  * *****************************************************************************/
 
 export const assertApplicative = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -420,11 +420,11 @@ export const assertApplicative = <
   A: T.Applicative<URI>,
   { a, ta, fai, fij, tfai, tfij }: {
     a: A;
-    ta: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
-    tfai: Kind<URI, [(a: A) => I, B, C, D]>;
-    tfij: Kind<URI, [(i: I) => J, B, C, D]>;
+    tfai: $<URI, [(a: A) => I, B, C, D]>;
+    tfij: $<URI, [(i: I) => J, B, C, D]>;
   },
 ): void => {
   // Identity: A.ap(A.of(x => x), v) ≡ v
@@ -454,7 +454,7 @@ export const assertApplicative = <
  * *****************************************************************************/
 
 export const assertAlt = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -464,9 +464,9 @@ export const assertAlt = <
 >(
   A: T.Alt<URI>,
   { ta, tb, tc, fai, fij }: {
-    ta: Kind<URI, [A, B, C, D]>;
-    tb: Kind<URI, [A, B, C, D]>;
-    tc: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
+    tb: $<URI, [A, B, C, D]>;
+    tc: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
   },
@@ -492,7 +492,7 @@ export const assertAlt = <
  * *****************************************************************************/
 
 export const assertPlus = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -502,9 +502,9 @@ export const assertPlus = <
 >(
   P: T.Plus<URI>,
   { ta, tb, tc, fai, fij }: {
-    ta: Kind<URI, [A, B, C, D]>;
-    tb: Kind<URI, [A, B, C, D]>;
-    tc: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
+    tb: $<URI, [A, B, C, D]>;
+    tc: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
   },
@@ -538,7 +538,7 @@ export const assertPlus = <
  * *****************************************************************************/
 
 export const assertAlternative = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -549,13 +549,13 @@ export const assertAlternative = <
   A: T.Alternative<URI>,
   { a, ta, tb, tc, fai, fij, tfai, tfij }: {
     a: A;
-    ta: Kind<URI, [A, B, C, D]>;
-    tb: Kind<URI, [A, B, C, D]>;
-    tc: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
+    tb: $<URI, [A, B, C, D]>;
+    tc: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
-    tfai: Kind<URI, [(a: A) => I, B, C, D]>;
-    tfij: Kind<URI, [(i: I) => J, B, C, D]>;
+    tfai: $<URI, [(a: A) => I, B, C, D]>;
+    tfij: $<URI, [(i: I) => J, B, C, D]>;
   },
 ): void => {
   // Distributivity: A.ap(A.alt(a, b), c) ≡ A.alt(A.ap(a, c), A.ap(b, c))
@@ -582,7 +582,7 @@ export const assertAlternative = <
  * *****************************************************************************/
 
 export const assertChain = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -613,7 +613,7 @@ export const assertChain = <
  * *****************************************************************************/
 
 export const assertMonad = <
-  URI extends URIS,
+  URI extends Kind,
   A,
   B = never,
   C = never,
@@ -648,7 +648,7 @@ export const assertMonad = <
  * *****************************************************************************/
 
 export const assertFoldable = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -658,7 +658,7 @@ export const assertFoldable = <
   F: T.Foldable<URI>,
   { a, tb, faia }: {
     a: A;
-    tb: Kind<URI, [I, B, C, D]>;
+    tb: $<URI, [I, B, C, D]>;
     faia: (a: A, i: I) => A;
   },
 ): void => {
@@ -677,7 +677,7 @@ export const assertFoldable = <
  * *****************************************************************************/
 
 export const assertExtend = <
-  URI extends URIS,
+  URI extends Kind,
   A = never,
   B = never,
   C = never,
@@ -687,11 +687,11 @@ export const assertExtend = <
 >(
   E: T.Extend<URI>,
   { ta, fai, fij, ftai, ftij }: {
-    ta: Kind<URI, [A, B, C, D]>;
+    ta: $<URI, [A, B, C, D]>;
     fai: (a: A) => I;
     fij: (i: I) => J;
-    ftai: (ta: Kind<URI, [A, B, C, D]>) => I;
-    ftij: (tb: Kind<URI, [I, B, C, D]>) => J;
+    ftai: (ta: $<URI, [A, B, C, D]>) => I;
+    ftij: (tb: $<URI, [I, B, C, D]>) => J;
   },
 ): void => {
   // Associativity: E.extend(f, E.extend(g, w)) ≡ E.extend(_w => f(E.extend(g, _w)), w)
@@ -709,7 +709,7 @@ export const assertExtend = <
  * *****************************************************************************/
 
 // export const assertComonad = <
-//   URI extends URIS,
+//   URI extends Kind,
 //   A = never,
 //   B = never,
 //   C = never,
@@ -719,11 +719,11 @@ export const assertExtend = <
 // >(
 //   C: T.Comonad<URI>,
 //   { ta, fai, fij, ftai, ftij }: {
-//     ta: Kind<URI, [A, B, C, D]>;
+//     ta: $<URI, [A, B, C, D]>;
 //     fai: (a: A) => I;
 //     fij: (i: I) => J;
-//     ftai: (ta: Kind<URI, [A, B, C, D]>) => I;
-//     ftij: (tb: Kind<URI, [I, B, C, D]>) => J;
+//     ftai: (ta: $<URI, [A, B, C, D]>) => I;
+//     ftij: (tb: $<URI, [I, B, C, D]>) => J;
 //   },
 // ): void => {
 //   // Left identity: C.extend(C.extract, w) ≡ w

--- a/testing/map.test.ts
+++ b/testing/map.test.ts
@@ -10,7 +10,7 @@ import { semigroupSum } from "../semigroup.ts";
 import { pipe } from "../fns.ts";
 
 Deno.test("Map zero", () => {
-  assertEquals(M.zero(), new Map());
+  assertEquals(M.zero(), new Map() as unknown as ReadonlyMap<never, never>);
 });
 
 Deno.test("Map empty", () => {
@@ -43,7 +43,7 @@ Deno.test("Map getShow", () => {
   const showNumber = { show: (n: number) => n.toString() };
   const Show = M.getShow(showNumber, showNumber);
 
-  assertEquals(Show.show(M.singleton(1, 1)), "new Map([[1, 1]])");
+  assertEquals(Show.show(M.singleton(1, 1)), "new ReadonlyMap([[1, 1]])");
 });
 
 Deno.test("Map getSetoid", () => {

--- a/testing/reader.test.ts
+++ b/testing/reader.test.ts
@@ -5,15 +5,17 @@ import { pipe } from "../fns.ts";
 
 import * as AS from "./assert.ts";
 
+const n = null as unknown as never;
+
 const assertEqualsR = (
   // deno-lint-ignore no-explicit-any
-  a: R.Reader<[number], any>,
+  a: R.Reader<number, any>,
   // deno-lint-ignore no-explicit-any
-  b: R.Reader<[number], any>,
+  b: R.Reader<number, any>,
 ) => assertEquals(a(0), b(0));
 
 Deno.test("Reader ask", () => {
-  assertEqualsR(R.ask<[number]>(), R.ask<[number]>());
+  assertEqualsR(R.ask<number>(), R.ask<number>());
 });
 
 Deno.test("Reader asks", () => {
@@ -26,21 +28,20 @@ Deno.test("Reader of", () => {
 });
 
 Deno.test("Reader ap", () => {
-  assertEqualsR(pipe(R.of(0), R.ap(R.of(AS.add))), R.of(1));
+  assertEquals(pipe(R.of(0), R.ap(R.of(AS.add)))(n), R.of(1)(n));
 });
 
 Deno.test("Reader map", () => {
-  assertEqualsR(pipe(R.of(0), R.map(AS.add)), R.of(1));
+  assertEquals(pipe(R.of(0), R.map(AS.add))(n), R.of(1)(n));
 });
 
 Deno.test("Reader join", () => {
-  const tta = R.asks((n: number) => R.of(n));
-  assertEquals(R.join(tta)(0), 0);
+  assertEquals(pipe(R.of(R.of(0)), R.join)(n), R.of(0)(n));
 });
 
 Deno.test("Reader chain", () => {
   const chain = R.chain((n: number) => R.of(n + 1));
-  assertEqualsR(chain(R.of(0)), R.of(1));
+  assertEquals(chain(R.of(0))(n), R.of(1)(n));
 });
 
 // Deno.test("Reader Do, bind, bindTo", () => {

--- a/testing/set.test.ts
+++ b/testing/set.test.ts
@@ -15,54 +15,53 @@ Deno.test("Set empty", () => {
   assertEquals(S.empty(), S.zero());
 });
 
-Deno.test("Set make", () => {
-  assertEquals(S.make(1), new Set([1]));
+Deno.test("Set set", () => {
+  assertEquals(S.set(1), new Set([1]));
 });
 
 Deno.test("Set elem", () => {
   const elem = S.elem(setoidNumber);
-  assertEquals(pipe(S.make(1), elem(1)), true);
-  assertEquals(pipe(S.make(1), elem(2)), false);
+  assertEquals(pipe(S.set(1), elem(1)), true);
+  assertEquals(pipe(S.set(1), elem(2)), false);
 });
 
 Deno.test("Set elemOf", () => {
   const elemOf = S.elemOf(setoidNumber);
-  assertEquals(pipe(1, elemOf(S.make(1))), true);
-  assertEquals(pipe(2, elemOf(S.make(1))), false);
+  assertEquals(pipe(1, elemOf(S.set(1))), true);
+  assertEquals(pipe(2, elemOf(S.set(1))), false);
 });
 
 Deno.test("Set isSubset", () => {
   const isSubset = S.isSubset(setoidNumber);
-  const ta = S.make(1);
-  const tb = S.make(1);
-  tb.add(2);
+  const ta = S.set(1);
+  const tb = S.set(1, 2);
   assertEquals(pipe(ta, isSubset(tb)), true);
   assertEquals(pipe(tb, isSubset(ta)), false);
 });
 
 Deno.test("Set union", () => {
   const union = S.union(setoidNumber);
-  assertEquals(pipe(S.make(1), union(S.make(2))), S.make(1, 2));
+  assertEquals(pipe(S.set(1), union(S.set(2))), S.set(1, 2));
 });
 
 Deno.test("Set intersection", () => {
   const intersection = S.intersection(setoidNumber);
-  assertEquals(pipe(S.make(1), intersection(S.make(2))), S.empty());
-  assertEquals(pipe(S.make(1, 2), intersection(S.make(2, 3))), S.make(2));
+  assertEquals(pipe(S.set(1), intersection(S.set(2))), S.empty());
+  assertEquals(pipe(S.set(1, 2), intersection(S.set(2, 3))), S.set(2));
 });
 
 Deno.test("Set compact", () => {
   const compact = S.compact(setoidNumber);
-  assertEquals(compact(S.make(1, 2, 3)), S.make(1, 2, 3));
+  assertEquals(compact(S.set(1, 2, 3)), S.set(1, 2, 3));
 });
 
 Deno.test("Set join", () => {
-  assertEquals(S.join(S.make(S.make(1, 2), S.make(2, 3))), S.make(1, 2, 3));
+  assertEquals(S.join(S.set(S.set(1, 2), S.set(2, 3))), S.set(1, 2, 3));
 });
 
 Deno.test("Set Functor", () => {
   AS.assertFunctor(S.Functor, {
-    ta: S.make(1, 2, 3),
+    ta: S.set(1, 2, 3),
     fai: AS.add,
     fij: AS.multiply,
   });
@@ -70,18 +69,18 @@ Deno.test("Set Functor", () => {
 
 Deno.test("Set Apply", () => {
   AS.assertApply(S.Apply, {
-    ta: S.make(1, 2, 3),
+    ta: S.set(1, 2, 3),
     fai: AS.add,
     fij: AS.multiply,
-    tfai: S.make(AS.add, AS.multiply),
-    tfij: S.make(AS.multiply, AS.add),
+    tfai: S.set(AS.add, AS.multiply),
+    tfij: S.set(AS.multiply, AS.add),
   });
 });
 
 Deno.test("Set Filterable", () => {
   AS.assertFilterable(S.Filterable, {
-    a: S.make(1, 2, 3),
-    b: S.make(2, 3, 4),
+    a: S.set(1, 2, 3),
+    b: S.set(2, 3, 4),
     f: (n: number) => n < 2,
     g: (n: number) => n > 4,
   });
@@ -90,7 +89,7 @@ Deno.test("Set Filterable", () => {
 Deno.test("Set Foldable", () => {
   AS.assertFoldable(S.Foldable, {
     a: 0,
-    tb: S.make(1, 2, 3),
+    tb: S.set(1, 2, 3),
     faia: (n: number, i: number) => n + i,
   });
 });
@@ -98,48 +97,48 @@ Deno.test("Set Foldable", () => {
 Deno.test("Set getShow", () => {
   const { show } = S.getShow({ show: (n: number) => n.toString() });
   assertEquals(show(S.empty()), "Set([])");
-  assertEquals(show(S.make(1, 2, 3)), "Set([1, 2, 3])");
+  assertEquals(show(S.set(1, 2, 3)), "Set([1, 2, 3])");
 });
 
 Deno.test("Set getSetoid", () => {
   const Setoid = S.getSetoid(setoidNumber);
   AS.assertSetoid(Setoid, {
-    a: S.make(1),
-    b: S.make(1),
-    c: S.make(1),
-    z: S.make(1, 2, 3),
+    a: S.set(1),
+    b: S.set(1),
+    c: S.set(1),
+    z: S.set(1, 2, 3),
   });
 });
 
 Deno.test("Set getUnionMonoid", () => {
   const Monoid = S.getUnionMonoid(setoidNumber);
   AS.assertMonoid(Monoid, {
-    a: S.make(1, 2),
-    b: S.make(2, 3),
-    c: S.make(3, 4),
+    a: S.set(1, 2),
+    b: S.set(2, 3),
+    c: S.set(3, 4),
   });
 });
 
 Deno.test("Set filter", () => {
   const filter = S.filter((n: number) => n > 0);
-  assertEquals(filter(S.make(1, 2, 3)), S.make(1, 2, 3));
-  assertEquals(filter(S.make(-1, 0, 1)), S.make(1));
+  assertEquals(filter(S.set(1, 2, 3)), S.set(1, 2, 3));
+  assertEquals(filter(S.set(-1, 0, 1)), S.set(1));
 });
 
 Deno.test("Set map", () => {
-  assertEquals(pipe(S.make(1, 2, 3), S.map(AS.add)), S.make(2, 3, 4));
+  assertEquals(pipe(S.set(1, 2, 3), S.map(AS.add)), S.set(2, 3, 4));
 });
 
 Deno.test("Set reduce", () => {
   const reduce = S.reduce((n: number, o: number) => n + o, 0);
   assertEquals(reduce(S.zero()), 0);
-  assertEquals(reduce(S.make(1, 2, 3)), 6);
+  assertEquals(reduce(S.set(1, 2, 3)), 6);
 });
 
 Deno.test("Set traverse", () => {
   const t1 = S.traverse(O.Applicative);
   const t2 = t1((n: number) => n === 0 ? O.none : O.some(n));
   assertEquals(t2(S.empty()), O.some(S.empty()));
-  assertEquals(t2(S.make(1, 2, 3)), O.some(S.make(1, 2, 3)));
-  assertEquals(t2(S.make(0, 1, 2)), O.none);
+  assertEquals(t2(S.set(1, 2, 3)), O.some(S.set(1, 2, 3)));
+  assertEquals(t2(S.set(0, 1, 2)), O.none);
 });

--- a/testing/traversal.test.ts
+++ b/testing/traversal.test.ts
@@ -63,8 +63,9 @@ Deno.test("Traversal modify", () => {
 
 Deno.test("Traversal filter", () => {
   const getAll = pipe(
-    T.toTraversal(A.Traversable)<number>(),
-    T.filter((n) => n > 0),
+    T.id<ReadonlyArray<number>>(),
+    T.traverse(A.Traversable),
+    T.filter((n: number) => n > 0),
     T.getAll,
   );
   assertEquals(getAll([]), []);
@@ -129,14 +130,22 @@ Deno.test("Traversal traverse", () => {
 
 Deno.test("Traversal foldMap", () => {
   const foldMapSum = T.foldMap(monoidSum);
-  const traverseNumberArray = pipe(T.toTraversal(A.Traversable)<number>());
-  const foldMap = pipe(traverseNumberArray, foldMapSum((n) => n));
+  const traverseNumberArray = pipe(T.traverse(A.Traversable));
+  const foldMap = pipe(
+    T.id<ReadonlyArray<number>>(),
+    traverseNumberArray,
+    foldMapSum((n) => n),
+  );
   assertEquals(foldMap([]), 0);
   assertEquals(foldMap([1, 2, 3]), 6);
 });
 
 Deno.test("Traversal getAll", () => {
-  const getAll = pipe(T.toTraversal(A.Traversable)<number>(), T.getAll);
+  const getAll = pipe(
+    T.id<ReadonlyArray<number>>(),
+    T.traverse(A.Traversable),
+    T.getAll,
+  );
   assertEquals(getAll([]), []);
   assertEquals(getAll([1, 2, 3]), [1, 2, 3]);
 });

--- a/these.ts
+++ b/these.ts
@@ -1,4 +1,4 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import * as E from "./either.ts";
@@ -12,15 +12,8 @@ export type Both<B, A> = { tag: "Both"; left: B; right: A };
 
 export type These<B, A> = Left<B> | Right<A> | Both<B, A>;
 
-export const URI = "These";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: These<_[1], _[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: These<this[1], this[0]>;
 }
 
 export function left<A = never, B = never>(left: B): These<B, A> {
@@ -95,11 +88,11 @@ export function reduce<A, O>(
   return (ta) => isLeft(ta) ? o : foao(o, ta.right);
 }
 
-export function traverse<VRI extends URIS>(
-  A: T.Applicative<VRI>,
+export function traverse<U extends Kind>(
+  A: T.Applicative<U>,
 ): <A, I, J, K, L>(
-  favi: (a: A) => Kind<VRI, [I, J, K, L]>,
-) => <B>(ta: These<B, A>) => Kind<VRI, [These<B, I>, J, K, L]> {
+  favi: (a: A) => $<U, [I, J, K, L]>,
+) => <B>(ta: These<B, A>) => $<U, [These<B, I>, J, K, L]> {
   return (favi) =>
     fold(
       (b) => A.of(left(b)),

--- a/traversable.ts
+++ b/traversable.ts
@@ -1,6 +1,4 @@
-// deno-lint-ignore-file no-explicit-any
-
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Functor } from "./functor.ts";
 import type { Foldable } from "./foldable.ts";
 import type { Applicative } from "./applicative.ts";
@@ -10,15 +8,14 @@ import type { Traversal } from "./traversal.ts";
  * Traversable
  * https://github.com/fantasyland/static-land/blob/master/docs/spec.md#traversable
  */
-export interface Traversable<URI extends URIS, _ extends any[] = any[]>
-  extends Functor<URI, _>, Foldable<URI, _> {
-  readonly traverse: <VRI extends URIS, __ extends any[] = any[]>(
-    A: Applicative<VRI, __>,
-  ) => <A, I, J extends __[0], K extends __[1], L extends __[2]>(
-    faui: (a: A) => Kind<VRI, [I, J, K, L]>,
-  ) => <B extends _[0], C extends _[1], D extends _[2]>(
-    ta: Kind<URI, [A, B, C, D]>,
-  ) => Kind<VRI, [Kind<URI, [I, B, C, D]>, J, K, L]>;
+export interface Traversable<U extends Kind> extends Functor<U>, Foldable<U> {
+  readonly traverse: <VRI extends Kind>(
+    A: Applicative<VRI>,
+  ) => <A, I, J, K, L>(
+    faui: (a: A) => $<VRI, [I, J, K, L]>,
+  ) => <B, C, D>(
+    ta: $<U, [A, B, C, D]>,
+  ) => $<VRI, [$<U, [I, B, C, D]>, J, K, L]>;
 }
 
 /**
@@ -27,19 +24,11 @@ export interface Traversable<URI extends URIS, _ extends any[] = any[]>
  * This is quite simple since Traversal and
  * Traversable have the same syntax and semantics.
  */
-export function toTraversal<URI extends URIS, _ extends any[] = any[]>(
-  T: Traversable<URI, _>,
-): <
-  A = never,
-  B extends _[0] = never,
-  C extends _[1] = never,
-  D extends _[2] = never,
->() => Traversal<
-  Kind<URI, [A, B, C, D]>,
-  A
-> {
+export function toTraversal<U extends Kind>(
+  T: Traversable<U>,
+): <A, B = never, C = never, D = never>() => Traversal<$<U, [A, B, C, D]>, A> {
   return () => ({
     tag: "Traversal",
-    traverse: T.traverse as any,
+    traverse: T.traverse,
   });
 }

--- a/traversal.ts
+++ b/traversal.ts
@@ -1,5 +1,5 @@
 import type * as T from "./types.ts";
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type { Predicate } from "./predicate.ts";
 import type { Refinement } from "./refinement.ts";
 import type { Either } from "./either.ts";
@@ -40,11 +40,11 @@ import {
 
 export type Traversal<S, A> = {
   readonly tag: "Traversal";
-  readonly traverse: <URI extends URIS>(
-    A: T.Applicative<URI>,
-  ) => <B = never, C = never, D = never>(
-    fata: (a: A) => Kind<URI, [A, B, C, D]>,
-  ) => (s: S) => Kind<URI, [S, B, C, D]>;
+  readonly traverse: <V extends Kind>(
+    A: T.Applicative<V>,
+  ) => <B, C, D>(
+    fata: (a: A) => $<V, [A, B, C, D]>,
+  ) => (s: S) => $<V, [S, B, C, D]>;
 };
 
 export type From<T> = T extends Traversal<infer S, infer _> ? S : never;
@@ -52,11 +52,11 @@ export type From<T> = T extends Traversal<infer S, infer _> ? S : never;
 export type To<T> = T extends Traversal<infer _, infer A> ? A : never;
 
 export function traversal<S, A>(
-  traverse: <URI extends URIS>(
-    A: T.Applicative<URI>,
+  traverse: <U extends Kind>(
+    A: T.Applicative<U>,
   ) => <B = never, C = never, D = never>(
-    fata: (a: A) => Kind<URI, [A, B, C, D]>,
-  ) => (s: S) => Kind<URI, [S, B, C, D]>,
+    fata: (a: A) => $<U, [A, B, C, D]>,
+  ) => (s: S) => $<U, [S, B, C, D]>,
 ): Traversal<S, A> {
   return ({ tag: "Traversal", traverse });
 }
@@ -209,10 +209,10 @@ export function atKey(
   return (sa) => composeLens(sa, _at);
 }
 
-export function traverse<URI extends URIS>(
-  T: T.Traversable<URI>,
+export function traverse<U extends Kind>(
+  T: T.Traversable<U>,
 ): <S, A, B = never, C = never, D = never>(
-  sa: Traversal<S, Kind<URI, [A, B, C, D]>>,
+  sa: Traversal<S, $<U, [A, B, C, D]>>,
 ) => Traversal<S, A> {
   const _traversal = toTraversal(T);
   return (sa) => composeTraversal(sa, _traversal());

--- a/tree.ts
+++ b/tree.ts
@@ -1,4 +1,4 @@
-import type { Kind, URIS } from "./kind.ts";
+import type { $, Kind } from "./kind.ts";
 import type * as T from "./types.ts";
 
 import * as A from "./array.ts";
@@ -12,15 +12,8 @@ export type Tree<A> = {
   readonly forest: Forest<A>;
 };
 
-export const URI = "Tree";
-
-export type URI = typeof URI;
-
-declare module "./kind.ts" {
-  // deno-lint-ignore no-explicit-any
-  export interface Kinds<_ extends any[]> {
-    [URI]: Tree<_[0]>;
-  }
+export interface URI extends Kind {
+  readonly type: Tree<this[0]>;
 }
 
 function draw(indentation: string, forest: Forest<string>): string {
@@ -72,19 +65,19 @@ export function reduce<A, O>(
   return (ta) => A.reduce(reducer, foao(o, ta.value))(ta.forest);
 }
 
-export function traverse<VRI extends URIS>(
-  V: T.Applicative<VRI>,
+export function traverse<V extends Kind>(
+  V: T.Applicative<V>,
 ): <A, I, J, K, L>(
-  favi: (a: A) => Kind<VRI, [I, J, K, L]>,
-) => (ta: Tree<A>) => Kind<VRI, [Tree<I>, J, K, L]> {
-  const traverseVRI = A.traverse(V);
+  favi: (a: A) => $<V, [I, J, K, L]>,
+) => (ta: Tree<A>) => $<V, [Tree<I>, J, K, L]> {
+  const traverseV = A.traverse(V);
   return (favi) => {
     const out =
-      <A, I, J, K, L>(_favi: (a: A) => Kind<VRI, [I, J, K, L]>) =>
-      (ta: Tree<A>): Kind<VRI, [Tree<I>, J, K, L]> =>
+      <A, I, J, K, L>(_favi: (a: A) => $<V, [I, J, K, L]>) =>
+      (ta: Tree<A>): $<V, [Tree<I>, J, K, L]> =>
         pipe(
           ta.forest,
-          traverseVRI(out(_favi)),
+          traverseV(out(_favi)),
           V.ap(pipe(_favi(ta.value), V.map(_make))),
         );
     return out(favi);


### PR DESCRIPTION
This commit implements the matech higher kinded type implementation documented here:

https://dev.to/matechs/encoding-of-hkts-in-typescript-5c3

There are a few changes from the version listed. Rather than "named" substitution holes it uses the same variadic method that fun already uses. This pretty much only affects the ease of use when extending Kind.