### PR TITLE
feat: implement ord 2.0

### DIFF
--- a/either.ts
+++ b/either.ts
@@ -14,6 +14,7 @@ import type { Show } from "./show.ts";
 import type { Traversable } from "./traversable.ts";
 
 import * as O from "./option.ts";
+import { fromCompare } from "./ord.ts";
 import { flow, isNotNil, pipe } from "./fns.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 
@@ -152,22 +153,13 @@ export function getOrd<A, B>(
   OB: Ord<B>,
   OA: Ord<A>,
 ): Ord<Either<B, A>> {
-  return ({
-    ...getSetoid(OB, OA),
-    lte: (b) => (a) => {
-      if (isLeft(a)) {
-        if (isLeft(b)) {
-          return OB.lte(b.left)(a.left);
-        }
-        return true;
-      }
-
-      if (isLeft(b)) {
-        return false;
-      }
-      return OA.lte(b.right)(a.right);
-    },
-  });
+  return fromCompare((fst, snd) =>
+    isLeft(fst)
+      ? isLeft(snd) ? OB.compare(fst.left, snd.left) : -1
+      : isLeft(snd)
+      ? 1
+      : OA.compare(fst.right, snd.right)
+  );
 }
 
 export function getLeftSemigroup<E = never, A = never>(

--- a/map.ts
+++ b/map.ts
@@ -10,7 +10,6 @@ import type { Show } from "./show.ts";
 
 import * as O from "./option.ts";
 import * as A from "./array.ts";
-import { toCompare } from "./ord.ts";
 import { fromEquals } from "./setoid.ts";
 import { flow, pipe } from "./fns.ts";
 
@@ -125,19 +124,16 @@ export function elem<A>(
 export function entries<B>(
   O: Ord<B>,
 ): <A>(ta: ReadonlyMap<B, A>) => ReadonlyArray<[B, A]> {
-  const _compare = toCompare(O);
   return (ta) =>
-    Array.from(ta.entries()).sort(([left], [right]) => _compare(left, right));
+    Array.from(ta.entries()).sort(([left], [right]) => O.compare(left, right));
 }
 
 export function keys<K>(O: Ord<K>): <A>(ta: ReadonlyMap<K, A>) => K[] {
-  const _compare = toCompare(O);
-  return (ta) => Array.from(ta.keys()).sort(_compare);
+  return (ta) => Array.from(ta.keys()).sort(O.compare);
 }
 
 export function values<A>(O: Ord<A>): <K>(ta: ReadonlyMap<K, A>) => A[] {
-  const _compare = toCompare(O);
-  return (ta) => Array.from(ta.values()).sort(_compare);
+  return (ta) => Array.from(ta.values()).sort(O.compare);
 }
 
 export function collect<B>(

--- a/newtype.ts
+++ b/newtype.ts
@@ -8,6 +8,7 @@
  * specified.
  */
 
+import type { Hold } from "./kind.ts";
 import type { Iso } from "./iso.ts";
 import type { Monoid } from "./monoid.ts";
 import type { Ord } from "./ord.ts";
@@ -30,13 +31,6 @@ import { unsafeCoerce } from "./fns.ts";
  */
 // deno-lint-ignore no-explicit-any
 const anyIso = I.iso<any, any>(unsafeCoerce, unsafeCoerce);
-
-/**
- * We use non-existing, non-exported symbols to keep
- * the
- */
-declare const Brand: unique symbol;
-declare const Representation: unique symbol;
 
 // ---
 // Types
@@ -68,10 +62,7 @@ declare const Representation: unique symbol;
  *
  * @since 2.0.0
  */
-export type Newtype<Brand, Representation> = {
-  readonly [Brand]: Brand;
-  readonly [Representation]: Representation;
-};
+export type Newtype<Brand, Representation> = Hold<Brand> & Representation;
 
 /**
  * Extracts the inner type value from a Newtype.

--- a/number.ts
+++ b/number.ts
@@ -1,8 +1,10 @@
 import type { Monoid } from "./monoid.ts";
-import type { Ord } from "./ord.ts";
+import type { Ord, Ordering } from "./ord.ts";
 import type { Semigroup } from "./semigroup.ts";
 import type { Setoid } from "./setoid.ts";
 import type { Show } from "./show.ts";
+
+import { fromCompare, sign } from "./ord.ts";
 
 // TODO; Implement newtypes for natural, integer, rational
 
@@ -22,6 +24,10 @@ export function add(right: number): (left: number) => number {
   return (left) => left + right;
 }
 
+export function compare(first: number, second: number): Ordering {
+  return sign(first - second);
+}
+
 export function emptyZero(): number {
   return 0;
 }
@@ -32,10 +38,7 @@ export function emptyOne(): number {
 
 export const SetoidNumber: Setoid<number> = { equals };
 
-export const OrdNumber: Ord<number> = {
-  equals,
-  lte,
-};
+export const OrdNumber: Ord<number> = fromCompare(compare);
 
 export const SemigroupNumberProduct: Semigroup<number> = {
   concat: multiply,
@@ -46,11 +49,11 @@ export const SemigroupNumberSum: Semigroup<number> = {
 };
 
 export const SemigroupNumberMax: Semigroup<number> = {
-  concat: (right) => (left) => right > left ? right : left,
+  concat: OrdNumber.max,
 };
 
 export const SemigroupNumberMin: Semigroup<number> = {
-  concat: (right) => (left) => right < left ? right : left,
+  concat: OrdNumber.min,
 };
 
 export const MonoidNumberProduct: Monoid<number> = {

--- a/option.ts
+++ b/option.ts
@@ -16,6 +16,7 @@ import type { Setoid } from "./setoid.ts";
 import type { Show } from "./show.ts";
 import type { Traversable } from "./traversable.ts";
 
+import { fromCompare } from "./ord.ts";
 import { createSequenceStruct, createSequenceTuple } from "./apply.ts";
 import { flow, identity, isNotNil, pipe } from "./fns.ts";
 
@@ -329,21 +330,13 @@ export function getSetoid<A>(S: Setoid<A>): Setoid<Option<A>> {
 }
 
 export function getOrd<A>(O: Ord<A>): Ord<Option<A>> {
-  return ({
-    ...getSetoid(O),
-    lte: (b) => (a) => {
-      if (a === b) {
-        return true;
-      }
-      if (isNone(a)) {
-        return true;
-      }
-      if (isNone(b)) {
-        return false;
-      }
-      return O.lte(b.value)(a.value);
-    },
-  });
+  return fromCompare((fst, snd) =>
+    isNone(fst)
+      ? isNone(snd) ? 0 : -1
+      : isNone(snd)
+      ? 1
+      : O.compare(fst.value, snd.value)
+  );
 }
 
 export function getSemigroup<A>(

--- a/semigroup.ts
+++ b/semigroup.ts
@@ -9,7 +9,6 @@
 
 import type { Ord } from "./ord.ts";
 
-import * as Or from "./ord.ts";
 import { pipe } from "./fns.ts";
 
 /**
@@ -256,7 +255,7 @@ export function struct<O extends Readonly<Record<string, unknown>>>(
  * @since 2.0.0
  */
 export function max<A>(O: Ord<A>): Semigroup<A> {
-  return { concat: Or.max(O) };
+  return { concat: O.max };
 }
 
 /**
@@ -285,7 +284,7 @@ export function max<A>(O: Ord<A>): Semigroup<A> {
  * @since 2.0.0
  */
 export function min<A>(O: Ord<A>): Semigroup<A> {
-  return { concat: Or.min(O) };
+  return { concat: O.min };
 }
 
 /**

--- a/setoid.ts
+++ b/setoid.ts
@@ -106,8 +106,8 @@ export function fromEquals<A>(
  *
  * @since 2.0.0
  */
-export function readonly<A>(Setoid: Setoid<A>): Setoid<Readonly<A>> {
-  return Setoid;
+export function readonly<A>(setoid: Setoid<A>): Setoid<Readonly<A>> {
+  return setoid;
 }
 
 /**
@@ -212,12 +212,12 @@ export function literal<A extends NonEmptyArray<Literal>>(
  *
  * @since 2.0.0
  */
-export function nullable<A>(Setoid: Setoid<A>): Setoid<A | null> {
+export function nullable<A>(setoid: Setoid<A>): Setoid<A | null> {
   return {
     equals: (second) => (first) =>
       (isNil(first) || isNil(second))
         ? first === second
-        : Setoid.equals(second)(first),
+        : setoid.equals(second)(first),
   };
 }
 
@@ -237,12 +237,12 @@ export function nullable<A>(Setoid: Setoid<A>): Setoid<A | null> {
  *
  * @since 2.0.0
  */
-export function undefinable<A>(Setoid: Setoid<A>): Setoid<A | undefined> {
+export function undefinable<A>(setoid: Setoid<A>): Setoid<A | undefined> {
   return {
     equals: (second) => (first) =>
       (isNil(first) || isNil(second))
         ? first === second
-        : Setoid.equals(second)(first),
+        : setoid.equals(second)(first),
   };
 }
 
@@ -262,8 +262,8 @@ export function undefinable<A>(Setoid: Setoid<A>): Setoid<A | undefined> {
  *
  * @since 2.0.0
  */
-export function record<A>(Setoid: Setoid<A>): Setoid<ReadonlyRecord<A>> {
-  const isSub = isSubrecord(Setoid);
+export function record<A>(setoid: Setoid<A>): Setoid<ReadonlyRecord<A>> {
+  const isSub = isSubrecord(setoid);
   return {
     equals: (second) => (first) => isSub(second)(first) && isSub(first)(second),
   };
@@ -285,11 +285,11 @@ export function record<A>(Setoid: Setoid<A>): Setoid<ReadonlyRecord<A>> {
  *
  * @since 2.0.0
  */
-export function array<A>(Setoid: Setoid<A>): Setoid<ReadonlyArray<A>> {
+export function array<A>(setoid: Setoid<A>): Setoid<ReadonlyArray<A>> {
   return {
     equals: (second) => (first) =>
       first.length === second.length &&
-      first.every((value, index) => Setoid.equals(second[index])(value)),
+      first.every((value, index) => setoid.equals(second[index])(value)),
   };
 }
 
@@ -338,9 +338,9 @@ export function tuple<T extends ReadonlyArray<Setoid<any>>>(
  * @since 2.0.0
  */
 export function struct<A>(
-  Setoids: { readonly [K in keyof A]: Setoid<A[K]> },
+  setoids: { readonly [K in keyof A]: Setoid<A[K]> },
 ): Setoid<{ readonly [K in keyof A]: A[K] }> {
-  const eqs = Object.entries(Setoids) as [keyof A, Setoid<A[keyof A]>][];
+  const eqs = Object.entries(setoids) as [keyof A, Setoid<A[keyof A]>][];
   return fromEquals((first, second) =>
     eqs.every(([key, { equals }]) => equals(second[key])(first[key]))
   );
@@ -471,7 +471,7 @@ export function union<I>(
  * type Person = { name: string, child?: Person };
  *
  * // Annotating the type is required for recursion
- * const person: Setoid<Person> = lazy("Person", () => pipe(
+ * const person: Setoid<Person> = lazy('Person', () => pipe(
  *   struct({ name: string }),
  *   intersect(partial({ child: person }))
  * ));

--- a/string.ts
+++ b/string.ts
@@ -1,7 +1,9 @@
 import type { Monoid } from "./monoid.ts";
-import type { Ord } from "./ord.ts";
+import type { Ord, Ordering } from "./ord.ts";
 import type { Semigroup } from "./semigroup.ts";
 import type { Setoid } from "./setoid.ts";
+
+import { fromCompare } from "./ord.ts";
 
 export function equals(second: string): (first: string) => boolean {
   return (first) => first === second;
@@ -19,10 +21,14 @@ export function empty(): string {
   return "";
 }
 
+export function compare(first: string, second: string): Ordering {
+  return first < second ? -1 : second < first ? 1 : 0;
+}
+
 export const SetoidString: Setoid<string> = { equals };
 
 export const SemigroupString: Semigroup<string> = { concat };
 
 export const MonoidString: Monoid<string> = { concat, empty };
 
-export const OrdString: Ord<string> = { lte, equals };
+export const OrdString: Ord<string> = fromCompare(compare);

--- a/testing/array.test.ts
+++ b/testing/array.test.ts
@@ -4,13 +4,11 @@ import {
   assertStrictEquals,
 } from "https://deno.land/std/testing/asserts.ts";
 
-import type { Ord } from "../ord.ts";
-
 import * as A from "../array.ts";
 import * as O from "../option.ts";
 import * as N from "../number.ts";
 import { SetoidBoolean } from "../boolean.ts";
-import { lessThanOrEqual, pipe, strictEquals } from "../fns.ts";
+import { pipe } from "../fns.ts";
 
 Deno.test("Array empty", () => assertEquals(A.empty(), []));
 
@@ -248,12 +246,8 @@ Deno.test("Array unzip", () => {
 });
 
 Deno.test("Array sort", () => {
-  const ordNever: Ord<never> = {
-    equals: strictEquals,
-    lte: lessThanOrEqual,
-  };
-  const t1 = [] as const;
-  const r1 = pipe(t1, A.sort(ordNever));
+  const t1 = [] as number[];
+  const r1 = pipe(t1, A.sort(N.OrdNumber));
   assertEquals(r1, t1);
   assertNotStrictEquals(r1, t1);
 

--- a/testing/ord.test.ts
+++ b/testing/ord.test.ts
@@ -1,125 +1,162 @@
 import {
   assertEquals,
-  assertExists,
+  assertStrictEquals,
 } from "https://deno.land/std/testing/asserts.ts";
-
-import type { Compare } from "../ord.ts";
 
 import * as O from "../ord.ts";
 import * as N from "../number.ts";
+import * as S from "../string.ts";
+import { pipe } from "../fns.ts";
 
-Deno.test("Ord toCompare", () => {
-  const compare = O.toCompare(N.OrdNumber);
-  assertEquals(typeof compare, "function");
-  assertEquals(compare(0, 0), 0);
-  assertEquals(compare(0, 1), -1);
-  assertEquals(compare(1, 0), 1);
+Deno.test("Ord sign", () => {
+  assertEquals(O.sign(Number.NEGATIVE_INFINITY), -1);
+  assertEquals(O.sign(Number.POSITIVE_INFINITY), 1);
+  assertEquals(O.sign(0), 0);
+  assertEquals(O.sign(-56), -1);
+  assertEquals(O.sign(56), 1);
+  assertEquals(O.sign(-0.34), -1);
+  assertEquals(O.sign(0.45), 1);
 });
 
-Deno.test("Ord lt", () => {
-  const lt = O.lt(N.OrdNumber);
+Deno.test("Ord fromCompare", () => {
+  const ord = O.fromCompare(N.compare);
+  const { lt, lte, equals, gte, gt, min, max, clamp, between, compare } = ord;
+
+  // lt
   assertEquals(lt(0)(0), false);
   assertEquals(lt(0)(1), false);
   assertEquals(lt(1)(0), true);
-});
 
-Deno.test("Ord gt", () => {
-  const gt = O.gt(N.OrdNumber);
+  // gt
   assertEquals(gt(0)(0), false);
   assertEquals(gt(0)(1), true);
   assertEquals(gt(1)(0), false);
-});
 
-Deno.test("Ord lte", () => {
-  const lte = O.lte(N.OrdNumber);
+  // lte
   assertEquals(lte(0)(0), true);
   assertEquals(lte(0)(1), false);
   assertEquals(lte(1)(0), true);
-});
 
-Deno.test("Ord gte", () => {
-  const gte = O.gte(N.OrdNumber);
+  // gte
   assertEquals(gte(0)(0), true);
   assertEquals(gte(1)(0), false);
   assertEquals(gte(0)(1), true);
-});
 
-Deno.test("Ord eq", () => {
-  const eq = O.eq(N.OrdNumber);
-  assertEquals(eq(0)(0), true);
-  assertEquals(eq(0)(1), false);
-  assertEquals(eq(1)(0), false);
-});
+  // equals
+  assertEquals(equals(0)(0), true);
+  assertEquals(equals(0)(1), false);
+  assertEquals(equals(1)(0), false);
 
-Deno.test("Ord min", () => {
-  const min = O.min(N.OrdNumber);
+  // min
   assertEquals(min(0)(0), 0);
   assertEquals(min(0)(1), 0);
   assertEquals(min(1)(0), 0);
-});
 
-Deno.test("Ord max", () => {
-  const max = O.max(N.OrdNumber);
+  // max
   assertEquals(max(0)(0), 0);
   assertEquals(max(0)(1), 1);
   assertEquals(max(1)(0), 1);
-});
 
-Deno.test("Ord clamp", () => {
-  const clamp = O.clamp(N.OrdNumber);
+  // clamp
   assertEquals(clamp(0, 2)(-1), 0);
   assertEquals(clamp(0, 2)(0), 0);
   assertEquals(clamp(0, 2)(1), 1);
   assertEquals(clamp(0, 2)(2), 2);
   assertEquals(clamp(0, 2)(3), 2);
-});
 
-Deno.test("Ord between", () => {
-  const between = O.between(N.OrdNumber);
+  // between
   assertEquals(between(0, 2)(-1), false);
   assertEquals(between(0, 2)(0), false);
   assertEquals(between(0, 2)(1), true);
   assertEquals(between(0, 10)(5), true);
   assertEquals(between(0, 2)(2), false);
   assertEquals(between(0, 2)(3), false);
+
+  // compare
+  assertEquals(compare(0, 0), 0);
+  assertEquals(compare(0, 1), -1);
+  assertEquals(compare(1, 0), 1);
 });
 
-Deno.test("Ord getOrdUtilities", () => {
-  assertExists(O.getOrdUtilities(N.OrdNumber));
+Deno.test("Ord trivial", () => {
+  // Every Date is the same!
+  const trivial = O.trivial<Date>();
+  const now = new Date();
+  const later = new Date(Date.now() + 60 * 60 * 1000);
+
+  assertEquals(trivial.compare(now, later), 0);
+  assertEquals(trivial.compare(later, now), 0);
+  assertEquals(trivial.compare(later, later), 0);
+  assertEquals(trivial.compare(now, now), 0);
 });
 
-Deno.test("Ord fromCompare", () => {
-  type Foo = { foo: number };
-  const compareFoo: Compare<Foo> = (left, right) =>
-    left.foo < right.foo ? -1 : left.foo > right.foo ? 1 : 0;
+Deno.test("Ord reverse", () => {
+  const reverse = O.reverse(N.OrdNumber);
 
-  const a = { foo: 0 };
-  const b = { foo: 0 };
-  const c = { foo: 2 };
-
-  const { equals, lte } = O.fromCompare(compareFoo);
-
-  assertEquals(equals(a)(a), true);
-  assertEquals(equals(a)(b), true);
-  assertEquals(equals(a)(c), false);
-  assertEquals(lte(c)(b), true);
-  assertEquals(lte(b)(c), false);
+  assertEquals(reverse.compare(0, 0), 0);
+  assertEquals(reverse.compare(0, 1), 1);
+  assertEquals(reverse.compare(1, 0), -1);
 });
 
-Deno.test("Ord createOrdTuple", () => {
-  const ordTuple = O.createOrdTuple(N.OrdNumber, N.OrdNumber);
+Deno.test("Ord tuple", () => {
+  const tuple = O.tuple(N.OrdNumber, N.OrdNumber);
 
-  assertEquals(O.toCompare(ordTuple)([1, 1], [2, 1]), -1);
-  assertEquals(O.toCompare(ordTuple)([1, 1], [1, 2]), -1);
-  assertEquals(O.toCompare(ordTuple)([1, 1], [1, 1]), 0);
-  assertEquals(O.toCompare(ordTuple)([1, 1], [1, 0]), 1);
-  assertEquals(O.toCompare(ordTuple)([1, 1], [0, 1]), 1);
+  assertEquals(tuple.compare([1, 1], [2, 1]), -1);
+  assertEquals(tuple.compare([1, 1], [1, 2]), -1);
+  assertEquals(tuple.compare([1, 1], [1, 1]), 0);
+  assertEquals(tuple.compare([1, 1], [1, 0]), 1);
+  assertEquals(tuple.compare([1, 1], [0, 1]), 1);
+});
+
+Deno.test("Ord struct", () => {
+  const tuple = O.struct({
+    name: S.OrdString,
+    age: N.OrdNumber,
+  });
+
+  assertEquals(
+    tuple.compare({ name: "Brandon", age: 37 }, { name: "Emily", age: 32 }),
+    -1,
+  );
+  assertEquals(
+    tuple.compare({ name: "Brandon", age: 37 }, { name: "Brandon", age: 32 }),
+    1,
+  );
+  assertEquals(
+    tuple.compare({ name: "Brandon", age: 37 }, { name: "Emily", age: 0 }),
+    -1,
+  );
+  assertEquals(
+    tuple.compare({ name: "Brandon", age: 37 }, { name: "Brandon", age: 37 }),
+    0,
+  );
 });
 
 Deno.test("Ord contramap", () => {
-  const ordFoo = O.contramap((foo: { foo: number }) => foo.foo)(N.OrdNumber);
+  type Person = { name: string; age: number };
+  const byAge = pipe(
+    N.OrdNumber,
+    O.contramap((p: Person) => p.age),
+  );
 
-  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 0 }), 1);
-  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 1 }), 0);
-  assertEquals(O.toCompare(ordFoo)({ foo: 1 }, { foo: 2 }), -1);
+  assertEquals(
+    byAge.compare({ name: "Brandon", age: 37 }, { name: "Emily", age: 32 }),
+    1,
+  );
+  assertEquals(
+    byAge.compare({ name: "Brandon", age: 37 }, { name: "Brandon", age: 37 }),
+    0,
+  );
+  assertEquals(
+    byAge.compare({ name: "Brandon", age: 37 }, { name: "Brian", age: 37 }),
+    0,
+  );
+  assertEquals(
+    byAge.compare({ name: "Brandon", age: 37 }, { name: "Patrick", age: 50 }),
+    -1,
+  );
+});
+
+Deno.test("Ord ContravariantOrd", () => {
+  assertStrictEquals(O.ContravariantOrd.contramap, O.contramap);
 });


### PR DESCRIPTION
While it 'might' be possible to implement most of schemable for Ord, I've opted to punt that to a maybe later date. On the other hand, creating adhoc max, min, clamp, etc functions from an ord is a pain. So for now I've decided to implement all of the comparison operations directly on Ord. Almost all ords are easier to create with the fromCompare constructor anyway.

* wrote the file header
* implemented all combinators and derivations
* modified all functions to adhere to new style guide
* documented every export
* upped test coverage to 100%

Fixes #108